### PR TITLE
Indicate if merging was successful

### DIFF
--- a/include/minisketch.h
+++ b/include/minisketch.h
@@ -88,20 +88,21 @@ void minisketch_add_uint64(minisketch* sketch, uint64_t element);
 
 /** Merge the elements of another sketch into this sketch.
  *
- * The resulting sketch will contain every element that existed in one but not
+ * After merging, `sketch` will contain every element that existed in one but not
  * both of the input sketches. It can be seen as an exclusive or operation on
- * the set elements.
+ * the set elements.  If the capacity of `other_sketch` is lower than `sketch`'s,
+ * merging reduces the capacity of `sketch` to that of `other_sketch`.
  *
- * If the capacity of `other_sketch` is lower than `sketch`'s, its capacity will be
- * reduce to that of `other_sketch`.
+ * This function returns the capacity of `sketch` after merging has been performed
+ * (where this capacity is at least 1), or 0 to indicate that merging has failed because
+ * the two input sketches differ in their element size or implementation. If 0 is
+ * returned, `sketch` (and its capacity) have not been modified.
  *
- * It is also possible to perform this operation directly on the serializations,
- * by performing an XOR on its bits.
- *
- * This function is a no-op if the two input sketches do not have the same element
- * size or implementation.
+ * It is also possible to perform this operation directly on the serializations
+ * of two sketches with the same element size and capacity by performing a bitwise XOR
+ * of the serializations.
  */
-void minisketch_merge(minisketch* sketch, const minisketch* other_sketch);
+size_t minisketch_merge(minisketch* sketch, const minisketch* other_sketch);
 
 /** Decode a sketch.
  *

--- a/include/minisketch.h
+++ b/include/minisketch.h
@@ -28,7 +28,8 @@ uint32_t minisketch_implementation_max();
 
 /** Construct a sketch for a given element size, implementation and capacity.
  *
- * If the combination of `bits` and `implementation` is unavailable, NULL is returned.
+ * If the combination of `bits` and `implementation` is unavailable, or if
+ * `capacity` is 0, NULL is returned.
  * If the result is not NULL, it must be destroyed using minisketch_destroy.
  */
 minisketch* minisketch_create(uint32_t bits, uint32_t implementation, size_t capacity);

--- a/src/minisketch.cpp
+++ b/src/minisketch.cpp
@@ -214,14 +214,14 @@ void minisketch_add_uint64(minisketch* sketch, uint64_t element) {
     s->Add(element);
 }
 
-void minisketch_merge(minisketch* sketch, const minisketch* other_sketch) {
+size_t minisketch_merge(minisketch* sketch, const minisketch* other_sketch) {
     Sketch* s1 = (Sketch*)sketch;
     const Sketch* s2 = (const Sketch*)other_sketch;
     s1->Check();
     s2->Check();
-    if (s1->Bits() != s2->Bits()) return;
-    if (s1->Implementation() != s2->Implementation()) return;
-    s1->Merge(s2);
+    if (s1->Bits() != s2->Bits()) return 0;
+    if (s1->Implementation() != s2->Implementation()) return 0;
+    return s1->Merge(s2);
 }
 
 ssize_t minisketch_decode(const minisketch* sketch, size_t max_elements, uint64_t* output) {

--- a/src/minisketch.cpp
+++ b/src/minisketch.cpp
@@ -132,6 +132,9 @@ uint32_t minisketch_implementation_max() {
 }
 
 minisketch* minisketch_create(uint32_t bits, uint32_t implementation, size_t capacity) {
+    if (capacity == 0) {
+        return nullptr;
+    }
     try {
         Sketch* sketch = Construct(bits, implementation);
         if (sketch) {

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -33,7 +33,7 @@ public:
     virtual void Add(uint64_t element) = 0;
     virtual void Serialize(unsigned char*) const = 0;
     virtual void Deserialize(const unsigned char*) = 0;
-    virtual void Merge(const Sketch* other_sketch) = 0;
+    virtual size_t Merge(const Sketch* other_sketch) = 0;
     virtual void SetSeed(uint64_t seed) = 0;
 
     virtual int Decode(int max_count, uint64_t* roots) const = 0;

--- a/src/sketch_impl.h
+++ b/src/sketch_impl.h
@@ -405,7 +405,7 @@ public:
         return roots.size();
     }
 
-    void Merge(const Sketch* other_sketch) override
+    size_t Merge(const Sketch* other_sketch) override
     {
         // Sad cast. This is safe only because the caller code in minisketch.cpp checks
         // that implementation and field size match.
@@ -414,6 +414,7 @@ public:
         for (size_t i = 0; i < m_syndromes.size(); ++i) {
             m_syndromes[i] += other->m_syndromes[i];
         }
+        return m_syndromes.size();
     }
 
     void SetSeed(uint64_t seed) override

--- a/src/test-exhaust.cpp
+++ b/src/test-exhaust.cpp
@@ -166,10 +166,14 @@ int main(void) {
     }
 
     int counts[65] = {0};
+    // Initialize capacities to 1 because a 0 capacity is not allowed.
+    for (int bits = 0; bits < 65; ++bits) {
+        counts[bits] = 1;
+    }
     for (int weight = 0; weight <= 40; weight += 1) {
         for (int bits = 2; bits <= 32; ++bits) {
             int count = counts[bits];
-            while (count < (1 << bits) && count < (1 << bits) && count * bits <= weight) {
+            while (count < (1 << bits) && count * bits <= weight) {
                 auto ret = TestAll(bits, 0, count, 4);
                 auto ret2 = TestAll(bits, 1, count, 4);
                 auto ret3 = TestAll(bits, 2, count, 4);


### PR DESCRIPTION
We could alternatively
 - return an `ssize_t` like `decode()`, and use `-1` to indicate failure. But I don't see a lot of potential for confusion, so I prefer the "booleanish" return value as proposed by this PR.
 - only return `0` / `1`