### PR TITLE
A few trivial fixups to make clang happy

### DIFF
--- a/src/lintrans.h
+++ b/src/lintrans.h
@@ -145,6 +145,6 @@ public:
 };
 
 /** A singleton for the identity transformation. */
-constexpr IdTrans ID_TRANS;
+constexpr IdTrans ID_TRANS{};
 
 #endif

--- a/src/sketch_impl.h
+++ b/src/sketch_impl.h
@@ -362,7 +362,7 @@ public:
         m_basis = F::FromSeed(dist(rng));
     }
 
-    size_t Syndromes() const { return m_syndromes.size(); }
+    size_t Syndromes() const override { return m_syndromes.size(); }
     void Init(int count) override { m_syndromes.assign(count, F()); }
 
     void Add(uint64_t val) override


### PR DESCRIPTION
Came across a few nits while working on a new build-system. The fixes are unrelated, but trivial and obvious.

The complaints are:

> fields/../lintrans.h:148:19: error: default initialization of an object of const type 'const IdTrans' without a user-provided default constructor
constexpr IdTrans ID_TRANS;

and

> fields/../sketch_impl.h:365:12: warning: 'Syndromes' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
