### PR TITLE
minisketch.h: avoid C++-ism which looks to C compilers like K&R C.

### DIFF
--- a/include/minisketch.h
+++ b/include/minisketch.h
@@ -24,7 +24,7 @@ int minisketch_bits_supported(uint32_t bits);
  * function call, inclusive. Note that not every combination of implementation
  * and element size may exist (see further).
 */
-uint32_t minisketch_implementation_max();
+uint32_t minisketch_implementation_max(void);
 
 /** Construct a sketch for a given element size, implementation and capacity.
  *


### PR DESCRIPTION
Otherwise gcc complains when -Wstrict-prototypes is used:

    minisketch/include/minisketch.h:27:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
     uint32_t minisketch_implementation_max();
     ^~~~~~~~

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>