### PR TITLE
Make field classes actually fields rather than field elements

### DIFF
--- a/src/fields/clmul_1byte.cpp
+++ b/src/fields/clmul_1byte.cpp
@@ -68,20 +68,20 @@ typedef Field<uint8_t, 8, 27, StatTable8, &SQR_TABLE_8, &SQR2_TABLE_8, nullptr, 
 
 Sketch* ConstructClMul1Byte(int bits, int implementation) {
     switch (bits) {
-    case 5: return new SketchImpl<Field5>(implementation);
-    case 8: return new SketchImpl<Field8>(implementation);
+    case 5: return new SketchImpl<Field5>(implementation, 5);
+    case 8: return new SketchImpl<Field8>(implementation, 8);
     }
     return nullptr;
 }
 
 Sketch* ConstructClMulTri1Byte(int bits, int implementation) {
     switch (bits) {
-    case 2: return new SketchImpl<FieldTri2>(implementation);
-    case 3: return new SketchImpl<FieldTri3>(implementation);
-    case 4: return new SketchImpl<FieldTri4>(implementation);
-    case 5: return new SketchImpl<FieldTri5>(implementation);
-    case 6: return new SketchImpl<FieldTri6>(implementation);
-    case 7: return new SketchImpl<FieldTri7>(implementation);
+    case 2: return new SketchImpl<FieldTri2>(implementation, 2);
+    case 3: return new SketchImpl<FieldTri3>(implementation, 3);
+    case 4: return new SketchImpl<FieldTri4>(implementation, 4);
+    case 5: return new SketchImpl<FieldTri5>(implementation, 5);
+    case 6: return new SketchImpl<FieldTri6>(implementation, 6);
+    case 7: return new SketchImpl<FieldTri7>(implementation, 7);
     }
     return nullptr;
 }

--- a/src/fields/clmul_2bytes.cpp
+++ b/src/fields/clmul_2bytes.cpp
@@ -89,24 +89,24 @@ typedef Field<uint16_t, 16, 43, StatTable16, &SQR_TABLE_16, &SQR2_TABLE_16, &SQR
 
 Sketch* ConstructClMul2Bytes(int bits, int implementation) {
     switch (bits) {
-    case 10: return new SketchImpl<Field10>(implementation);
-    case 11: return new SketchImpl<Field11>(implementation);
-    case 12: return new SketchImpl<Field12>(implementation);
-    case 13: return new SketchImpl<Field13>(implementation);
-    case 14: return new SketchImpl<Field14>(implementation);
-    case 16: return new SketchImpl<Field16>(implementation);
+    case 10: return new SketchImpl<Field10>(implementation, 10);
+    case 11: return new SketchImpl<Field11>(implementation, 11);
+    case 12: return new SketchImpl<Field12>(implementation, 12);
+    case 13: return new SketchImpl<Field13>(implementation, 13);
+    case 14: return new SketchImpl<Field14>(implementation, 14);
+    case 16: return new SketchImpl<Field16>(implementation, 16);
     }
     return nullptr;
 }
 
 Sketch* ConstructClMulTri2Bytes(int bits, int implementation) {
     switch (bits) {
-    case 9: return new SketchImpl<FieldTri9>(implementation);
-    case 10: return new SketchImpl<FieldTri10>(implementation);
-    case 11: return new SketchImpl<FieldTri11>(implementation);
-    case 12: return new SketchImpl<FieldTri12>(implementation);
-    case 14: return new SketchImpl<FieldTri14>(implementation);
-    case 15: return new SketchImpl<FieldTri15>(implementation);
+    case 9: return new SketchImpl<FieldTri9>(implementation, 9);
+    case 10: return new SketchImpl<FieldTri10>(implementation, 10);
+    case 11: return new SketchImpl<FieldTri11>(implementation, 11);
+    case 12: return new SketchImpl<FieldTri12>(implementation, 12);
+    case 14: return new SketchImpl<FieldTri14>(implementation, 14);
+    case 15: return new SketchImpl<FieldTri15>(implementation, 15);
     }
     return nullptr;
 }

--- a/src/fields/clmul_3bytes.cpp
+++ b/src/fields/clmul_3bytes.cpp
@@ -98,25 +98,25 @@ typedef Field<uint32_t, 24, 27, StatTable24, &SQR_TABLE_24, &SQR2_TABLE_24, &SQR
 
 Sketch* ConstructClMul3Bytes(int bits, int implementation) {
     switch (bits) {
-    case 17: return new SketchImpl<Field17>(implementation);
-    case 18: return new SketchImpl<Field18>(implementation);
-    case 19: return new SketchImpl<Field19>(implementation);
-    case 20: return new SketchImpl<Field20>(implementation);
-    case 21: return new SketchImpl<Field21>(implementation);
-    case 23: return new SketchImpl<Field23>(implementation);
-    case 24: return new SketchImpl<Field24>(implementation);
+    case 17: return new SketchImpl<Field17>(implementation, 17);
+    case 18: return new SketchImpl<Field18>(implementation, 18);
+    case 19: return new SketchImpl<Field19>(implementation, 19);
+    case 20: return new SketchImpl<Field20>(implementation, 20);
+    case 21: return new SketchImpl<Field21>(implementation, 21);
+    case 23: return new SketchImpl<Field23>(implementation, 23);
+    case 24: return new SketchImpl<Field24>(implementation, 24);
     }
     return nullptr;
 }
 
 Sketch* ConstructClMulTri3Bytes(int bits, int implementation) {
     switch (bits) {
-    case 17: return new SketchImpl<FieldTri17>(implementation);
-    case 18: return new SketchImpl<FieldTri18>(implementation);
-    case 20: return new SketchImpl<FieldTri20>(implementation);
-    case 21: return new SketchImpl<FieldTri21>(implementation);
-    case 22: return new SketchImpl<FieldTri22>(implementation);
-    case 23: return new SketchImpl<FieldTri23>(implementation);
+    case 17: return new SketchImpl<FieldTri17>(implementation, 17);
+    case 18: return new SketchImpl<FieldTri18>(implementation, 18);
+    case 20: return new SketchImpl<FieldTri20>(implementation, 20);
+    case 21: return new SketchImpl<FieldTri21>(implementation, 21);
+    case 22: return new SketchImpl<FieldTri22>(implementation, 22);
+    case 23: return new SketchImpl<FieldTri23>(implementation, 23);
     }
     return nullptr;
 }

--- a/src/fields/clmul_4bytes.cpp
+++ b/src/fields/clmul_4bytes.cpp
@@ -96,23 +96,23 @@ typedef Field<uint32_t, 32, 141, StatTable32, &SQR_TABLE_32, &SQR2_TABLE_32, &SQ
 
 Sketch* ConstructClMul4Bytes(int bits, int implementation) {
     switch (bits) {
-    case 25: return new SketchImpl<Field25>(implementation);
-    case 26: return new SketchImpl<Field26>(implementation);
-    case 27: return new SketchImpl<Field27>(implementation);
-    case 29: return new SketchImpl<Field29>(implementation);
-    case 31: return new SketchImpl<Field31>(implementation);
-    case 32: return new SketchImpl<Field32>(implementation);
+    case 25: return new SketchImpl<Field25>(implementation, 25);
+    case 26: return new SketchImpl<Field26>(implementation, 26);
+    case 27: return new SketchImpl<Field27>(implementation, 27);
+    case 29: return new SketchImpl<Field29>(implementation, 29);
+    case 31: return new SketchImpl<Field31>(implementation, 31);
+    case 32: return new SketchImpl<Field32>(implementation, 32);
     }
     return nullptr;
 }
 
 Sketch* ConstructClMulTri4Bytes(int bits, int implementation) {
     switch (bits) {
-    case 25: return new SketchImpl<FieldTri25>(implementation);
-    case 28: return new SketchImpl<FieldTri28>(implementation);
-    case 29: return new SketchImpl<FieldTri29>(implementation);
-    case 30: return new SketchImpl<FieldTri30>(implementation);
-    case 31: return new SketchImpl<FieldTri31>(implementation);
+    case 25: return new SketchImpl<FieldTri25>(implementation, 25);
+    case 28: return new SketchImpl<FieldTri28>(implementation, 28);
+    case 29: return new SketchImpl<FieldTri29>(implementation, 29);
+    case 30: return new SketchImpl<FieldTri30>(implementation, 30);
+    case 31: return new SketchImpl<FieldTri31>(implementation, 31);
     }
     return nullptr;
 }

--- a/src/fields/clmul_5bytes.cpp
+++ b/src/fields/clmul_5bytes.cpp
@@ -106,25 +106,25 @@ typedef Field<uint64_t, 40, 57, StatTable40, &SQR_TABLE_40, &SQR2_TABLE_40, &SQR
 
 Sketch* ConstructClMul5Bytes(int bits, int implementation) {
     switch (bits) {
-    case 33: return new SketchImpl<Field33>(implementation);
-    case 34: return new SketchImpl<Field34>(implementation);
-    case 35: return new SketchImpl<Field35>(implementation);
-    case 36: return new SketchImpl<Field36>(implementation);
-    case 37: return new SketchImpl<Field37>(implementation);
-    case 38: return new SketchImpl<Field38>(implementation);
-    case 39: return new SketchImpl<Field39>(implementation);
-    case 40: return new SketchImpl<Field40>(implementation);
+    case 33: return new SketchImpl<Field33>(implementation, 33);
+    case 34: return new SketchImpl<Field34>(implementation, 34);
+    case 35: return new SketchImpl<Field35>(implementation, 35);
+    case 36: return new SketchImpl<Field36>(implementation, 36);
+    case 37: return new SketchImpl<Field37>(implementation, 37);
+    case 38: return new SketchImpl<Field38>(implementation, 38);
+    case 39: return new SketchImpl<Field39>(implementation, 39);
+    case 40: return new SketchImpl<Field40>(implementation, 40);
     }
     return nullptr;
 }
 
 Sketch* ConstructClMulTri5Bytes(int bits, int implementation) {
     switch (bits) {
-    case 33: return new SketchImpl<FieldTri33>(implementation);
-    case 34: return new SketchImpl<FieldTri34>(implementation);
-    case 35: return new SketchImpl<FieldTri35>(implementation);
-    case 36: return new SketchImpl<FieldTri36>(implementation);
-    case 39: return new SketchImpl<FieldTri39>(implementation);
+    case 33: return new SketchImpl<FieldTri33>(implementation, 33);
+    case 34: return new SketchImpl<FieldTri34>(implementation, 34);
+    case 35: return new SketchImpl<FieldTri35>(implementation, 35);
+    case 36: return new SketchImpl<FieldTri36>(implementation, 36);
+    case 39: return new SketchImpl<FieldTri39>(implementation, 39);
     }
     return nullptr;
 }

--- a/src/fields/clmul_6bytes.cpp
+++ b/src/fields/clmul_6bytes.cpp
@@ -105,24 +105,24 @@ typedef Field<uint64_t, 48, 45, StatTable48, &SQR_TABLE_48, &SQR2_TABLE_48, &SQR
 
 Sketch* ConstructClMul6Bytes(int bits, int implementation) {
     switch (bits) {
-    case 41: return new SketchImpl<Field41>(implementation);
-    case 42: return new SketchImpl<Field42>(implementation);
-    case 43: return new SketchImpl<Field43>(implementation);
-    case 44: return new SketchImpl<Field44>(implementation);
-    case 45: return new SketchImpl<Field45>(implementation);
-    case 47: return new SketchImpl<Field47>(implementation);
-    case 48: return new SketchImpl<Field48>(implementation);
+    case 41: return new SketchImpl<Field41>(implementation, 41);
+    case 42: return new SketchImpl<Field42>(implementation, 42);
+    case 43: return new SketchImpl<Field43>(implementation, 43);
+    case 44: return new SketchImpl<Field44>(implementation, 44);
+    case 45: return new SketchImpl<Field45>(implementation, 45);
+    case 47: return new SketchImpl<Field47>(implementation, 47);
+    case 48: return new SketchImpl<Field48>(implementation, 48);
     }
     return nullptr;
 }
 
 Sketch* ConstructClMulTri6Bytes(int bits, int implementation) {
     switch (bits) {
-    case 41: return new SketchImpl<FieldTri41>(implementation);
-    case 42: return new SketchImpl<FieldTri42>(implementation);
-    case 44: return new SketchImpl<FieldTri44>(implementation);
-    case 46: return new SketchImpl<FieldTri46>(implementation);
-    case 47: return new SketchImpl<FieldTri47>(implementation);
+    case 41: return new SketchImpl<FieldTri41>(implementation, 41);
+    case 42: return new SketchImpl<FieldTri42>(implementation, 42);
+    case 44: return new SketchImpl<FieldTri44>(implementation, 44);
+    case 46: return new SketchImpl<FieldTri46>(implementation, 46);
+    case 47: return new SketchImpl<FieldTri47>(implementation, 47);
     }
     return nullptr;
 }

--- a/src/fields/clmul_7bytes.cpp
+++ b/src/fields/clmul_7bytes.cpp
@@ -105,24 +105,24 @@ typedef Field<uint64_t, 56, 149, StatTable56, &SQR_TABLE_56, &SQR2_TABLE_56, &SQ
 
 Sketch* ConstructClMul7Bytes(int bits, int implementation) {
     switch (bits) {
-    case 49: return new SketchImpl<Field49>(implementation);
-    case 50: return new SketchImpl<Field50>(implementation);
-    case 51: return new SketchImpl<Field51>(implementation);
-    case 52: return new SketchImpl<Field52>(implementation);
-    case 53: return new SketchImpl<Field53>(implementation);
-    case 54: return new SketchImpl<Field54>(implementation);
-    case 55: return new SketchImpl<Field55>(implementation);
-    case 56: return new SketchImpl<Field56>(implementation);
+    case 49: return new SketchImpl<Field49>(implementation, 49);
+    case 50: return new SketchImpl<Field50>(implementation, 50);
+    case 51: return new SketchImpl<Field51>(implementation, 51);
+    case 52: return new SketchImpl<Field52>(implementation, 52);
+    case 53: return new SketchImpl<Field53>(implementation, 53);
+    case 54: return new SketchImpl<Field54>(implementation, 54);
+    case 55: return new SketchImpl<Field55>(implementation, 55);
+    case 56: return new SketchImpl<Field56>(implementation, 56);
     }
     return nullptr;
 }
 
 Sketch* ConstructClMulTri7Bytes(int bits, int implementation) {
     switch (bits) {
-    case 49: return new SketchImpl<FieldTri49>(implementation);
-    case 52: return new SketchImpl<FieldTri52>(implementation);
-    case 54: return new SketchImpl<FieldTri54>(implementation);
-    case 55: return new SketchImpl<FieldTri55>(implementation);
+    case 49: return new SketchImpl<FieldTri49>(implementation, 49);
+    case 52: return new SketchImpl<FieldTri52>(implementation, 52);
+    case 54: return new SketchImpl<FieldTri54>(implementation, 54);
+    case 55: return new SketchImpl<FieldTri55>(implementation, 55);
     }
     return nullptr;
 }

--- a/src/fields/clmul_8bytes.cpp
+++ b/src/fields/clmul_8bytes.cpp
@@ -112,23 +112,23 @@ typedef Field<uint64_t, 64, 27, StatTable64, &SQR_TABLE_64, &SQR2_TABLE_64, &SQR
 
 Sketch* ConstructClMul8Bytes(int bits, int implementation) {
     switch (bits) {
-    case 57: return new SketchImpl<Field57>(implementation);
-    case 58: return new SketchImpl<Field58>(implementation);
-    case 59: return new SketchImpl<Field59>(implementation);
-    case 61: return new SketchImpl<Field61>(implementation);
-    case 62: return new SketchImpl<Field62>(implementation);
-    case 64: return new SketchImpl<Field64>(implementation);
+    case 57: return new SketchImpl<Field57>(implementation, 57);
+    case 58: return new SketchImpl<Field58>(implementation, 58);
+    case 59: return new SketchImpl<Field59>(implementation, 59);
+    case 61: return new SketchImpl<Field61>(implementation, 61);
+    case 62: return new SketchImpl<Field62>(implementation, 62);
+    case 64: return new SketchImpl<Field64>(implementation, 63);
     }
     return nullptr;
 }
 
 Sketch* ConstructClMulTri8Bytes(int bits, int implementation) {
     switch (bits) {
-    case 57: return new SketchImpl<FieldTri57>(implementation);
-    case 58: return new SketchImpl<FieldTri58>(implementation);
-    case 60: return new SketchImpl<FieldTri60>(implementation);
-    case 62: return new SketchImpl<FieldTri62>(implementation);
-    case 63: return new SketchImpl<FieldTri63>(implementation);
+    case 57: return new SketchImpl<FieldTri57>(implementation, 57);
+    case 58: return new SketchImpl<FieldTri58>(implementation, 58);
+    case 60: return new SketchImpl<FieldTri60>(implementation, 60);
+    case 62: return new SketchImpl<FieldTri62>(implementation, 62);
+    case 63: return new SketchImpl<FieldTri63>(implementation, 63);
     }
     return nullptr;
 }

--- a/src/fields/generic_1byte.cpp
+++ b/src/fields/generic_1byte.cpp
@@ -70,13 +70,13 @@ typedef Field<uint8_t, 8, 27, StatTable8, DynTable8, &SQR_TABLE_8, &QRT_TABLE_8>
 Sketch* ConstructGeneric1Byte(int bits, int implementation)
 {
     switch (bits) {
-    case 2: return new SketchImpl<Field2>(implementation);
-    case 3: return new SketchImpl<Field3>(implementation);
-    case 4: return new SketchImpl<Field4>(implementation);
-    case 5: return new SketchImpl<Field5>(implementation);
-    case 6: return new SketchImpl<Field6>(implementation);
-    case 7: return new SketchImpl<Field7>(implementation);
-    case 8: return new SketchImpl<Field8>(implementation);
+    case 2: return new SketchImpl<Field2>(implementation, 2);
+    case 3: return new SketchImpl<Field3>(implementation, 3);
+    case 4: return new SketchImpl<Field4>(implementation, 4);
+    case 5: return new SketchImpl<Field5>(implementation, 5);
+    case 6: return new SketchImpl<Field6>(implementation, 6);
+    case 7: return new SketchImpl<Field7>(implementation, 7);
+    case 8: return new SketchImpl<Field8>(implementation, 8);
     default: return nullptr;
     }
 }

--- a/src/fields/generic_2bytes.cpp
+++ b/src/fields/generic_2bytes.cpp
@@ -77,14 +77,14 @@ typedef Field<uint16_t, 16, 43, StatTable16, DynTable16, &SQR_TABLE_16, &QRT_TAB
 Sketch* ConstructGeneric2Bytes(int bits, int implementation)
 {
     switch (bits) {
-    case 9: return new SketchImpl<Field9>(implementation);
-    case 10: return new SketchImpl<Field10>(implementation);
-    case 11: return new SketchImpl<Field11>(implementation);
-    case 12: return new SketchImpl<Field12>(implementation);
-    case 13: return new SketchImpl<Field13>(implementation);
-    case 14: return new SketchImpl<Field14>(implementation);
-    case 15: return new SketchImpl<Field15>(implementation);
-    case 16: return new SketchImpl<Field16>(implementation);
+    case 9: return new SketchImpl<Field9>(implementation, 9);
+    case 10: return new SketchImpl<Field10>(implementation, 10);
+    case 11: return new SketchImpl<Field11>(implementation, 11);
+    case 12: return new SketchImpl<Field12>(implementation, 12);
+    case 13: return new SketchImpl<Field13>(implementation, 13);
+    case 14: return new SketchImpl<Field14>(implementation, 14);
+    case 15: return new SketchImpl<Field15>(implementation, 15);
+    case 16: return new SketchImpl<Field16>(implementation, 16);
     default: return nullptr;
     }
 }

--- a/src/fields/generic_3bytes.cpp
+++ b/src/fields/generic_3bytes.cpp
@@ -77,14 +77,14 @@ typedef Field<uint32_t, 24, 27, StatTable24, DynTable24, &SQR_TABLE_24, &QRT_TAB
 Sketch* ConstructGeneric3Bytes(int bits, int implementation)
 {
     switch (bits) {
-    case 17: return new SketchImpl<Field17>(implementation);
-    case 18: return new SketchImpl<Field18>(implementation);
-    case 19: return new SketchImpl<Field19>(implementation);
-    case 20: return new SketchImpl<Field20>(implementation);
-    case 21: return new SketchImpl<Field21>(implementation);
-    case 22: return new SketchImpl<Field22>(implementation);
-    case 23: return new SketchImpl<Field23>(implementation);
-    case 24: return new SketchImpl<Field24>(implementation);
+    case 17: return new SketchImpl<Field17>(implementation, 17);
+    case 18: return new SketchImpl<Field18>(implementation, 18);
+    case 19: return new SketchImpl<Field19>(implementation, 19);
+    case 20: return new SketchImpl<Field20>(implementation, 20);
+    case 21: return new SketchImpl<Field21>(implementation, 21);
+    case 22: return new SketchImpl<Field22>(implementation, 22);
+    case 23: return new SketchImpl<Field23>(implementation, 23);
+    case 24: return new SketchImpl<Field24>(implementation, 24);
     default: return nullptr;
     }
 }

--- a/src/fields/generic_4bytes.cpp
+++ b/src/fields/generic_4bytes.cpp
@@ -77,14 +77,14 @@ typedef Field<uint32_t, 32, 141, StatTable32, DynTable32, &SQR_TABLE_32, &QRT_TA
 Sketch* ConstructGeneric4Bytes(int bits, int implementation)
 {
     switch (bits) {
-    case 25: return new SketchImpl<Field25>(implementation);
-    case 26: return new SketchImpl<Field26>(implementation);
-    case 27: return new SketchImpl<Field27>(implementation);
-    case 28: return new SketchImpl<Field28>(implementation);
-    case 29: return new SketchImpl<Field29>(implementation);
-    case 30: return new SketchImpl<Field30>(implementation);
-    case 31: return new SketchImpl<Field31>(implementation);
-    case 32: return new SketchImpl<Field32>(implementation);
+    case 25: return new SketchImpl<Field25>(implementation, 25);
+    case 26: return new SketchImpl<Field26>(implementation, 26);
+    case 27: return new SketchImpl<Field27>(implementation, 27);
+    case 28: return new SketchImpl<Field28>(implementation, 28);
+    case 29: return new SketchImpl<Field29>(implementation, 29);
+    case 30: return new SketchImpl<Field30>(implementation, 30);
+    case 31: return new SketchImpl<Field31>(implementation, 31);
+    case 32: return new SketchImpl<Field32>(implementation, 32);
     default: return nullptr;
     }
 }

--- a/src/fields/generic_5bytes.cpp
+++ b/src/fields/generic_5bytes.cpp
@@ -15,7 +15,6 @@
 #include "../sketch.h"
 
 namespace {
-
 // 33 bit field
 typedef RecLinTrans<uint64_t, 6, 6, 6, 5, 5, 5> StatTable33;
 typedef RecLinTrans<uint64_t, 4, 4, 4, 4, 4, 4, 3, 3, 3> DynTable33;
@@ -77,14 +76,14 @@ typedef Field<uint64_t, 40, 57, StatTable40, DynTable40, &SQR_TABLE_40, &QRT_TAB
 Sketch* ConstructGeneric5Bytes(int bits, int implementation)
 {
     switch (bits) {
-    case 33: return new SketchImpl<Field33>(implementation);
-    case 34: return new SketchImpl<Field34>(implementation);
-    case 35: return new SketchImpl<Field35>(implementation);
-    case 36: return new SketchImpl<Field36>(implementation);
-    case 37: return new SketchImpl<Field37>(implementation);
-    case 38: return new SketchImpl<Field38>(implementation);
-    case 39: return new SketchImpl<Field39>(implementation);
-    case 40: return new SketchImpl<Field40>(implementation);
+    case 33: return new SketchImpl<Field33>(implementation, 33);
+    case 34: return new SketchImpl<Field34>(implementation, 34);
+    case 35: return new SketchImpl<Field35>(implementation, 35);
+    case 36: return new SketchImpl<Field36>(implementation, 36);
+    case 37: return new SketchImpl<Field37>(implementation, 37);
+    case 38: return new SketchImpl<Field38>(implementation, 38);
+    case 39: return new SketchImpl<Field39>(implementation, 39);
+    case 40: return new SketchImpl<Field40>(implementation, 40);
     default: return nullptr;
     }
 }

--- a/src/fields/generic_6bytes.cpp
+++ b/src/fields/generic_6bytes.cpp
@@ -77,14 +77,14 @@ typedef Field<uint64_t, 48, 45, StatTable48, DynTable48, &SQR_TABLE_48, &QRT_TAB
 Sketch* ConstructGeneric6Bytes(int bits, int implementation)
 {
     switch (bits) {
-    case 41: return new SketchImpl<Field41>(implementation);
-    case 42: return new SketchImpl<Field42>(implementation);
-    case 43: return new SketchImpl<Field43>(implementation);
-    case 44: return new SketchImpl<Field44>(implementation);
-    case 45: return new SketchImpl<Field45>(implementation);
-    case 46: return new SketchImpl<Field46>(implementation);
-    case 47: return new SketchImpl<Field47>(implementation);
-    case 48: return new SketchImpl<Field48>(implementation);
+    case 41: return new SketchImpl<Field41>(implementation, 41);
+    case 42: return new SketchImpl<Field42>(implementation, 42);
+    case 43: return new SketchImpl<Field43>(implementation, 43);
+    case 44: return new SketchImpl<Field44>(implementation, 44);
+    case 45: return new SketchImpl<Field45>(implementation, 45);
+    case 46: return new SketchImpl<Field46>(implementation, 46);
+    case 47: return new SketchImpl<Field47>(implementation, 47);
+    case 48: return new SketchImpl<Field48>(implementation, 48);
     default: return nullptr;
     }
 }

--- a/src/fields/generic_7bytes.cpp
+++ b/src/fields/generic_7bytes.cpp
@@ -77,14 +77,14 @@ typedef Field<uint64_t, 56, 149, StatTable56, DynTable56, &SQR_TABLE_56, &QRT_TA
 Sketch* ConstructGeneric7Bytes(int bits, int implementation)
 {
     switch (bits) {
-    case 49: return new SketchImpl<Field49>(implementation);
-    case 50: return new SketchImpl<Field50>(implementation);
-    case 51: return new SketchImpl<Field51>(implementation);
-    case 52: return new SketchImpl<Field52>(implementation);
-    case 53: return new SketchImpl<Field53>(implementation);
-    case 54: return new SketchImpl<Field54>(implementation);
-    case 55: return new SketchImpl<Field55>(implementation);
-    case 56: return new SketchImpl<Field56>(implementation);
+    case 49: return new SketchImpl<Field49>(implementation, 49);
+    case 50: return new SketchImpl<Field50>(implementation, 50);
+    case 51: return new SketchImpl<Field51>(implementation, 51);
+    case 52: return new SketchImpl<Field52>(implementation, 52);
+    case 53: return new SketchImpl<Field53>(implementation, 53);
+    case 54: return new SketchImpl<Field54>(implementation, 54);
+    case 55: return new SketchImpl<Field55>(implementation, 55);
+    case 56: return new SketchImpl<Field56>(implementation, 56);
     default: return nullptr;
     }
 }

--- a/src/fields/generic_8bytes.cpp
+++ b/src/fields/generic_8bytes.cpp
@@ -77,14 +77,14 @@ typedef Field<uint64_t, 64, 27, StatTable64, DynTable64, &SQR_TABLE_64, &QRT_TAB
 Sketch* ConstructGeneric8Bytes(int bits, int implementation)
 {
     switch (bits) {
-    case 57: return new SketchImpl<Field57>(implementation);
-    case 58: return new SketchImpl<Field58>(implementation);
-    case 59: return new SketchImpl<Field59>(implementation);
-    case 60: return new SketchImpl<Field60>(implementation);
-    case 61: return new SketchImpl<Field61>(implementation);
-    case 62: return new SketchImpl<Field62>(implementation);
-    case 63: return new SketchImpl<Field63>(implementation);
-    case 64: return new SketchImpl<Field64>(implementation);
+    case 57: return new SketchImpl<Field57>(implementation, 57);
+    case 58: return new SketchImpl<Field58>(implementation, 58);
+    case 59: return new SketchImpl<Field59>(implementation, 59);
+    case 60: return new SketchImpl<Field60>(implementation, 60);
+    case 61: return new SketchImpl<Field61>(implementation, 61);
+    case 62: return new SketchImpl<Field62>(implementation, 62);
+    case 63: return new SketchImpl<Field63>(implementation, 63);
+    case 64: return new SketchImpl<Field64>(implementation, 64);
     default: return nullptr;
     }
 }

--- a/src/sketch_impl.h
+++ b/src/sketch_impl.h
@@ -15,43 +15,43 @@
 
 /** Compute the remainder of a polynomial division of val by mod, putting the result in mod. */
 template<typename F>
-void PolyMod(const std::vector<F>& mod, std::vector<F>& val) {
+void PolyMod(const std::vector<typename F::Elem>& mod, std::vector<typename F::Elem>& val, const F& field) {
     size_t modsize = mod.size();
-    CHECK_SAFE(modsize > 0 && mod.back().IsOne());
+    CHECK_SAFE(modsize > 0 && mod.back() == 1);
     if (val.size() < modsize) return;
-    CHECK_SAFE(!val.back().IsZero());
+    CHECK_SAFE(val.back() != 0);
     while (val.size() >= modsize) {
-        F term = val.back();
+        auto term = val.back();
         val.pop_back();
-        if (!term.IsZero()) {
-            typename F::Multiplier mul(term);
+        if (term != 0) {
+            typename F::Multiplier mul(field, term);
             for (size_t x = 0; x < mod.size() - 1; ++x) {
-                val[val.size() - modsize + 1 + x] += mul(mod[x]);
+                val[val.size() - modsize + 1 + x] ^= mul(mod[x]);
             }
         }
     }
-    while (val.size() > 0 && val.back().IsZero()) val.pop_back();
+    while (val.size() > 0 && val.back() == 0) val.pop_back();
 }
 
 /** Compute the quotient of a polynomial division of val by mod, putting the quotient in div and the remainder in val. */
 template<typename F>
-void DivMod(const std::vector<F>& mod, std::vector<F>& val, std::vector<F>& div) {
+void DivMod(const std::vector<typename F::Elem>& mod, std::vector<typename F::Elem>& val, std::vector<typename F::Elem>& div, const F& field) {
     size_t modsize = mod.size();
-    CHECK_SAFE(mod.size() > 0 && mod.back().IsOne());
+    CHECK_SAFE(mod.size() > 0 && mod.back() == 1);
     if (val.size() < mod.size()) {
         div.clear();
         return;
     }
-    CHECK_SAFE(!val.back().IsZero());
+    CHECK_SAFE(val.back() != 0);
     div.resize(val.size() - mod.size() + 1);
     while (val.size() >= modsize) {
-        F term = val.back();
+        auto term = val.back();
         div[val.size() - modsize] = term;
         val.pop_back();
-        if (!term.IsZero()) {
-            typename F::Multiplier mul(term);
+        if (term != 0) {
+            typename F::Multiplier mul(field, term);
             for (size_t x = 0; x < mod.size() - 1; ++x) {
-                val[val.size() - modsize + 1 + x] += mul(mod[x]);
+                val[val.size() - modsize + 1 + x] ^= mul(mod[x]);
             }
         }
     }
@@ -59,12 +59,12 @@ void DivMod(const std::vector<F>& mod, std::vector<F>& val, std::vector<F>& div)
 
 /** Make a polynomial monic. */
 template<typename F>
-F MakeMonic(std::vector<F>& a) {
-    CHECK_SAFE(!a.back().IsZero());
-    if (a.back().IsOne()) return F::Zero();
-    auto inv = a.back().Inv();
-    typename F::Multiplier mul(inv);
-    a.back() = F::One();
+typename F::Elem MakeMonic(std::vector<typename F::Elem>& a, const F& field) {
+    CHECK_SAFE(a.back() != 0);
+    if (a.back() == 1) return 0;
+    auto inv = field.Inv(a.back());
+    typename F::Multiplier mul(field, inv);
+    a.back() = 1;
     for (size_t i = 0; i < a.size() - 1; ++i) {
         a[i] = mul(a[i]);
     }
@@ -73,43 +73,43 @@ F MakeMonic(std::vector<F>& a) {
 
 /** Compute the GCD of two polynomials, putting the result in a. b will be cleared. */
 template<typename F>
-void GCD(std::vector<F>& a, std::vector<F>& b) {
+void GCD(std::vector<typename F::Elem>& a, std::vector<typename F::Elem>& b, const F& field) {
     if (a.size() < b.size()) std::swap(a, b);
     while (b.size() > 0) {
         if (b.size() == 1) {
             a.resize(1);
-            a[0] = F::One();
+            a[0] = 1;
             return;
         }
-        MakeMonic<F>(b);
-        PolyMod<F>(b, a);
+        MakeMonic(b, field);
+        PolyMod(b, a, field);
         std::swap(a, b);
     }
 }
 
 /** Square a polynomial. */
 template<typename F>
-void Sqr(std::vector<F>& poly) {
+void Sqr(std::vector<typename F::Elem>& poly, const F& field) {
     if (poly.size() == 0) return;
     poly.resize(poly.size() * 2 - 1);
     for (int x = poly.size() - 1; x >= 0; --x) {
-        poly[x] = (x & 1) ? F::Zero() : poly[x / 2].Sqr();
+        poly[x] = (x & 1) ? 0 : field.Sqr(poly[x / 2]);
     }
 }
 
 /** Compute the trace map of (param*x) modulo mod, putting the result in out. */
 template<typename F>
-void TraceMod(const std::vector<F>& mod, std::vector<F>& out, const F& param) {
+void TraceMod(const std::vector<typename F::Elem>& mod, std::vector<typename F::Elem>& out, const typename F::Elem& param, const F& field) {
     out.reserve(mod.size() * 2);
     out.resize(2);
-    out[0] = F::Zero();
+    out[0] = 0;
     out[1] = param;
 
-    for (int i = 0; i < F::BITS - 1; ++i) {
-        Sqr<F>(out);
+    for (int i = 0; i < field.Bits() - 1; ++i) {
+        Sqr(out, field);
         if (out.size() < 2) out.resize(2);
         out[1] = param;
-        PolyMod<F>(mod, out);
+        PolyMod(mod, out, field);
     }
 }
 
@@ -125,13 +125,13 @@ void TraceMod(const std::vector<F>& mod, std::vector<F>& out, const F& param) {
  * case the polynomial cannot be fully factored.
  */
 template<typename F>
-bool RecFindRoots(std::vector<std::vector<F>>& stack, size_t pos, std::vector<F>& roots, bool fully_factorizable, int depth, F randv) {
+bool RecFindRoots(std::vector<std::vector<typename F::Elem>>& stack, size_t pos, std::vector<typename F::Elem>& roots, bool fully_factorizable, int depth, typename F::Elem randv, const F& field) {
     auto& ppoly = stack[pos];
     // We assert ppoly.size() > 1 (instead of just ppoly.size() > 0) to additionally exclude
     // constants polynomials because
     //  - ppoly is not constant initially (this is ensured by FindRoots()), and
     //  - we never recurse on a constant polynomial.
-    CHECK_SAFE(ppoly.size() > 1 && ppoly.back().IsOne());
+    CHECK_SAFE(ppoly.size() > 1 && ppoly.back() == 1);
     /* 1st degree input: constant term is the root. */
     if (ppoly.size() == 2) {
         roots.push_back(ppoly[0]);
@@ -139,16 +139,16 @@ bool RecFindRoots(std::vector<std::vector<F>>& stack, size_t pos, std::vector<F>
     }
     /* 2nd degree input: use direct quadratic solver. */
     if (ppoly.size() == 3) {
-        CHECK_RETURN(!ppoly[1].IsZero(), false); // Equations of the form (x^2 + a) have two identical solutions; contradicts square-free assumption. */
-        auto input = ppoly[0] * ppoly[1].Inv().Sqr();
-        auto root = input.Qrt();
-        if (root.Sqr() + root != input) {
+        CHECK_RETURN(ppoly[1] != 0, false); // Equations of the form (x^2 + a) have two identical solutions; contradicts square-free assumption. */
+        auto input = field.Mul(ppoly[0], field.Sqr(field.Inv(ppoly[1])));
+        auto root = field.Qrt(input);
+        if ((field.Sqr(root) ^ root) != input) {
             CHECK_SAFE(!fully_factorizable);
             return false; // No root found.
         }
-        auto sol = root * ppoly[1];
+        auto sol = field.Mul(root, ppoly[1]);
         roots.push_back(sol);
-        roots.push_back(sol + ppoly[1]);
+        roots.push_back(sol ^ ppoly[1]);
         return true;
     }
     /* 3rd degree input and more: recurse further. */
@@ -164,7 +164,7 @@ bool RecFindRoots(std::vector<std::vector<F>>& stack, size_t pos, std::vector<F>
     for (int iter = 0;; ++iter) {
         // Compute the polynomial (trace(x*randv) mod poly(x)) symbolically,
         // and put the result in `trace`.
-        TraceMod<F>(poly, trace, randv);
+        TraceMod(poly, trace, randv, field);
 
         if (iter >= 1 && !fully_factorizable) {
             // If the polynomial cannot be factorized completely (it has an
@@ -201,12 +201,12 @@ bool RecFindRoots(std::vector<std::vector<F>>& stack, size_t pos, std::vector<F>
             // fully factorizable (or at least pushes the test down the
             // recursion to factors which are smaller and thus faster).
             tmp = trace;
-            Sqr<F>(tmp);
+            Sqr(tmp, field);
             for (size_t i = 0; i < trace.size(); ++i) {
-                tmp[i] += trace[i];
+                tmp[i] ^= trace[i];
             }
-            while (tmp.size() && tmp.back().IsZero()) tmp.pop_back();
-            PolyMod<F>(poly, tmp);
+            while (tmp.size() && tmp.back() == 0) tmp.pop_back();
+            PolyMod(poly, tmp, field);
 
             // Whenever the test fails, we can immediately abort the root
             // finding. Whenever it succeeds, we can remember and pass down
@@ -221,30 +221,30 @@ bool RecFindRoots(std::vector<std::vector<F>>& stack, size_t pos, std::vector<F>
             // polynomial further into buckets, each corresponding to a subset
             // of 2^(BITS-depth) roots. If after depth splits the degree of
             // the polynomial is >= 2^(BITS-depth), something is wrong.
-            CHECK_RETURN((poly.size() - 2) >> (F::BITS - depth) == 0, false);
+            CHECK_RETURN((poly.size() - 2) >> (field.Bits() - depth) == 0, false);
         }
 
         depth++;
         // In every iteration we multiply randv by 2. As a result, the set
         // of randv values forms a GF(2)-linearly independent basis of splits.
-        randv = randv.Mul2();
+        randv = field.Mul2(randv);
         tmp = poly;
-        GCD<F>(trace, tmp);
+        GCD(trace, tmp, field);
         if (trace.size() != poly.size() && trace.size() > 1) break;
     }
-    MakeMonic<F>(trace);
-    DivMod<F>(trace, poly, tmp);
+    MakeMonic(trace, field);
+    DivMod(trace, poly, tmp, field);
     // At this point, the stack looks like [... (poly) tmp trace], and we want to recursively
     // find roots of trace and tmp (= poly/trace). As we don't care about poly anymore, move
     // trace into its position first.
     std::swap(poly, trace);
     // Now the stack is [... (trace) tmp ...]. First we factor tmp (at pos = pos+1), and then
     // we factor trace (at pos = pos).
-    if (!RecFindRoots<F>(stack, pos + 1, roots, fully_factorizable, depth, randv)) return false;
+    if (!RecFindRoots(stack, pos + 1, roots, fully_factorizable, depth, randv, field)) return false;
     // The stack position pos contains trace, the polynomial with all of poly's roots which (after
     // multiplication with randv) have trace 0. This is never the case for irreducible factors
     // (which always end up in tmp), so we can set fully_factorizable to true when recursing.
-    bool ret = RecFindRoots<F>(stack, pos, roots, true, depth, randv);
+    bool ret = RecFindRoots(stack, pos, roots, true, depth, randv, field);
     // Because of the above, recursion can never fail here.
     CHECK_SAFE(ret);
     return ret;
@@ -259,46 +259,46 @@ bool RecFindRoots(std::vector<std::vector<F>>& stack, size_t pos, std::vector<F>
  * has fewer roots than its degree, the empty vector is returned.
  */
 template<typename F>
-std::vector<F> FindRoots(const std::vector<F>& poly, F basis) {
-    std::vector<F> roots;
+std::vector<typename F::Elem> FindRoots(const std::vector<typename F::Elem>& poly, typename F::Elem basis, const F& field) {
+    std::vector<typename F::Elem> roots;
     CHECK_RETURN(poly.size() != 0, {});
-    CHECK_RETURN(!basis.IsZero(), {});
+    CHECK_RETURN(basis != 0, {});
     if (poly.size() == 1) return roots; // No roots when the polynomial is a constant.
     roots.reserve(poly.size() - 1);
-    std::vector<std::vector<F>> stack = {poly};
+    std::vector<std::vector<typename F::Elem>> stack = {poly};
 
     // Invoke the recursive factorization algorithm.
-    if (!RecFindRoots<F>(stack, 0, roots, false, 0, basis)) {
+    if (!RecFindRoots(stack, 0, roots, false, 0, basis, field)) {
         // Not fully factorizable.
-        return std::vector<F>();
+        return {};
     }
     CHECK_RETURN(poly.size() - 1 == roots.size(), {});
     return roots;
 }
 
 template<typename F>
-std::vector<F> BerlekampMassey(const std::vector<F>& syndromes, size_t max_degree) {
+std::vector<typename F::Elem> BerlekampMassey(const std::vector<typename F::Elem>& syndromes, size_t max_degree, const F& field) {
     std::vector<typename F::Multiplier> table;
-    std::vector<F> current, prev, tmp;
+    std::vector<typename F::Elem> current, prev, tmp;
     current.reserve(syndromes.size() / 2 + 1);
     prev.reserve(syndromes.size() / 2 + 1);
     tmp.reserve(syndromes.size() / 2 + 1);
     current.resize(1);
-    current[0] = F::One();
+    current[0] = 1;
     prev.resize(1);
-    prev[0] = F::One();
-    F b = F::One(), b_inv = F::One();
+    prev[0] = 1;
+    typename F::Elem b = 1, b_inv = 1;
     bool b_have_inv = true;
     table.reserve(syndromes.size());
 
     for (size_t n = 0; n != syndromes.size(); ++n) {
-        table.emplace_back(syndromes[n]);
-        F discrepancy = syndromes[n];
-        for (size_t i = 1; i < current.size(); ++i) discrepancy += table[n - i](current[i]);
-        if (!discrepancy.IsZero()) {
+        table.emplace_back(field, syndromes[n]);
+        auto discrepancy = syndromes[n];
+        for (size_t i = 1; i < current.size(); ++i) discrepancy ^= table[n - i](current[i]);
+        if (discrepancy != 0) {
             int x = n + 1 - (current.size() - 1) - (prev.size() - 1);
             if (!b_have_inv) {
-                b_inv = b.Inv();
+                b_inv = field.Inv(b);
                 b_have_inv = true;
             }
             bool swap = 2 * (current.size() - 1) <= n;
@@ -307,8 +307,8 @@ std::vector<F> BerlekampMassey(const std::vector<F>& syndromes, size_t max_degre
                 tmp = current;
                 current.resize(prev.size() + x);
             }
-            typename F::Multiplier mul(discrepancy * b_inv);
-            for (size_t i = 0; i < prev.size(); ++i) current[i + x] += mul(prev[i]);
+            typename F::Multiplier mul(field, field.Mul(discrepancy, b_inv));
+            for (size_t i = 0; i < prev.size(); ++i) current[i + x] ^= mul(prev[i]);
             if (swap) {
                 std::swap(prev, tmp);
                 b = discrepancy;
@@ -316,66 +316,68 @@ std::vector<F> BerlekampMassey(const std::vector<F>& syndromes, size_t max_degre
             }
         }
     }
-    CHECK_RETURN(current.size() && !current.back().IsZero(), {});
+    CHECK_RETURN(current.size() && current.back() != 0, {});
     return current;
 }
 
 template<typename F>
-std::vector<F> ReconstructAllSyndromes(const std::vector<F>& odd_syndromes) {
-    std::vector<F> all_syndromes;
+std::vector<typename F::Elem> ReconstructAllSyndromes(const std::vector<typename F::Elem>& odd_syndromes, const F& field) {
+    std::vector<typename F::Elem> all_syndromes;
     all_syndromes.resize(odd_syndromes.size() * 2);
     for (size_t i = 0; i < odd_syndromes.size(); ++i) {
         all_syndromes[i * 2] = odd_syndromes[i];
-        all_syndromes[i * 2 + 1] = all_syndromes[i].Sqr();
+        all_syndromes[i * 2 + 1] = field.Sqr(all_syndromes[i]);
     }
     return all_syndromes;
 }
 
 template<typename F>
-void AddToOddSyndromes(std::vector<F>& osyndromes, F data) {
-    auto sqr = data.Sqr();
-    typename F::Multiplier mul(sqr);
+void AddToOddSyndromes(std::vector<typename F::Elem>& osyndromes, typename F::Elem data, const F& field) {
+    auto sqr = field.Sqr(data);
+    typename F::Multiplier mul(field, sqr);
     for (auto& osyndrome : osyndromes) {
-        osyndrome += data;
+        osyndrome ^= data;
         data = mul(data);
     }
 }
 
 template<typename F>
-std::vector<F> FullDecode(const std::vector<F>& osyndromes) {
-    auto asyndromes = ReconstructAllSyndromes<F>(osyndromes);
-    auto poly = BerlekampMassey<F>(asyndromes);
+std::vector<typename F::Elem> FullDecode(const std::vector<typename F::Elem>& osyndromes, const F& field) {
+    auto asyndromes = ReconstructAllSyndromes<typename F::Elem>(osyndromes, field);
+    auto poly = BerlekampMassey(asyndromes, field);
     std::reverse(poly.begin(), poly.end());
-    return FindRoots<F>(poly);
+    return FindRoots(poly, field);
 }
 
 template<typename F>
 class SketchImpl final : public Sketch
 {
-    std::vector<F> m_syndromes;
-    F m_basis;
+    const F m_field;
+    std::vector<typename F::Elem> m_syndromes;
+    typename F::Elem m_basis;
 
 public:
-    SketchImpl(int implementation) : Sketch(implementation, F::BITS) {
+    template<typename... Args>
+    SketchImpl(int implementation, int bits, const Args&... args) : Sketch(implementation, bits), m_field(args...) {
         std::random_device rng;
         std::uniform_int_distribution<uint64_t> dist;
-        m_basis = F::FromSeed(dist(rng));
+        m_basis = m_field.FromSeed(dist(rng));
     }
 
     size_t Syndromes() const override { return m_syndromes.size(); }
-    void Init(int count) override { m_syndromes.assign(count, F()); }
+    void Init(int count) override { m_syndromes.assign(count, 0); }
 
     void Add(uint64_t val) override
     {
-        F elem = F::FromUint64(val);
-        AddToOddSyndromes(m_syndromes, elem);
+        auto elem = m_field.FromUint64(val);
+        AddToOddSyndromes(m_syndromes, elem, m_field);
     }
 
     void Serialize(unsigned char* ptr) const override
     {
         BitWriter writer(ptr);
         for (const auto& val : m_syndromes) {
-            val.Serialize(writer);
+            m_field.Serialize(writer, val);
         }
         writer.Flush();
     }
@@ -384,23 +386,23 @@ public:
     {
         BitReader reader(ptr);
         for (auto& val : m_syndromes) {
-            val = F::Deserialize(reader);
+            val = m_field.Deserialize(reader);
         }
     }
 
     int Decode(int max_count, uint64_t* out) const override
     {
-        auto all_syndromes = ReconstructAllSyndromes(m_syndromes);
-        auto poly = BerlekampMassey(all_syndromes, max_count);
+        auto all_syndromes = ReconstructAllSyndromes(m_syndromes, m_field);
+        auto poly = BerlekampMassey(all_syndromes, max_count, m_field);
         if (poly.size() == 0) return -1;
         if (poly.size() == 1) return 0;
         if ((int)poly.size() > 1 + max_count) return -1;
         std::reverse(poly.begin(), poly.end());
-        auto roots = FindRoots(poly, m_basis);
+        auto roots = FindRoots(poly, m_basis, m_field);
         if (roots.size() == 0) return -1;
 
         for (const auto& root : roots) {
-            *(out++) = root.ToUint64();
+            *(out++) = m_field.ToUint64(root);
         }
         return roots.size();
     }
@@ -412,7 +414,7 @@ public:
         const SketchImpl* other = static_cast<const SketchImpl*>(other_sketch);
         m_syndromes.resize(std::min(m_syndromes.size(), other->m_syndromes.size()));
         for (size_t i = 0; i < m_syndromes.size(); ++i) {
-            m_syndromes[i] += other->m_syndromes[i];
+            m_syndromes[i] ^= other->m_syndromes[i];
         }
         return m_syndromes.size();
     }
@@ -420,9 +422,9 @@ public:
     void SetSeed(uint64_t seed) override
     {
         if (seed == (uint64_t)-1) {
-            m_basis = F::One();
+            m_basis = 1;
         } else {
-            m_basis = F::FromSeed(seed);
+            m_basis = m_field.FromSeed(seed);
         }
     }
 };


### PR DESCRIPTION
Rather than having Field classes whose instances are field elements, have classes whose instances are the fields themselves. This is a step towards having a generic (small binary size) field class that can handle multiple field sizes simultaneously.
