### PR TITLE
Add C++ wrapper class in minisketch.h header

### DIFF
--- a/include/minisketch.h
+++ b/include/minisketch.h
@@ -26,10 +26,19 @@ int minisketch_bits_supported(uint32_t bits);
 */
 uint32_t minisketch_implementation_max(void);
 
+/** Determine if the a combination of bits and implementation number is available.
+ *
+ * Returns 1 if it is, 0 otherwise.
+ */
+int minisketch_implementation_supported(uint32_t bits, uint32_t implementation);
+
 /** Construct a sketch for a given element size, implementation and capacity.
  *
  * If the combination of `bits` and `implementation` is unavailable, or if
- * `capacity` is 0, NULL is returned.
+ * `capacity` is 0, NULL is returned. If minisketch_implementation_supported
+ * returns 1 for the specified bits and implementation, this will always succeed
+ * (except when allocation fails).
+ *
  * If the result is not NULL, it must be destroyed using minisketch_destroy.
  */
 minisketch* minisketch_create(uint32_t bits, uint32_t implementation, size_t capacity);

--- a/include/minisketch.h
+++ b/include/minisketch.h
@@ -1,13 +1,21 @@
 #ifndef _MINISKETCH_H_
 #define _MINISKETCH_H_ 1
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdint.h>
 #include <stdlib.h>
 #include <unistd.h>
+
+#ifdef __cplusplus
+#  if __cplusplus >= 201103L
+#    include <memory>
+#    include <vector>
+#    include <cassert>
+#    if __cplusplus >= 201703L
+#      include <optional>
+#    endif // __cplusplus >= 201703L
+#  endif // __cplusplus >= 201103L
+extern "C" {
+#endif // __cplusplus
 
 /** Opaque type for decoded sketches. */
 typedef struct minisketch minisketch;
@@ -160,6 +168,152 @@ size_t minisketch_compute_max_elements(uint32_t bits, size_t capacity, uint32_t 
 
 #ifdef __cplusplus
 }
-#endif
 
-#endif
+#if __cplusplus >= 201103L
+/** Simple RAII C++11 wrapper around the minisketch API. */
+class Minisketch
+{
+    struct Deleter
+    {
+        void operator()(minisketch* ptr) const
+        {
+            minisketch_destroy(ptr);
+        }
+    };
+
+    std::unique_ptr<minisketch, Deleter> m_minisketch;
+
+public:
+    /** See minisketch_bits_supported(). */
+    static bool BitsSupported(uint32_t bits) noexcept { return minisketch_bits_supported(bits); }
+
+    /** minisketch_implementation_supported(). */
+    static bool ImplementationSupported(uint32_t bits, uint32_t implementation) noexcept { return minisketch_implementation_supported(bits, implementation); }
+
+    /** See minisketch_implementation_max(). */
+    static uint32_t MaxImplementation() noexcept { return minisketch_implementation_max(); }
+
+    /** See minisketch_compute_capacity(). */
+    static size_t ComputeCapacity(uint32_t bits, size_t max_elements, uint32_t fpbits) noexcept { return minisketch_compute_capacity(bits, max_elements, fpbits); }
+
+    /** See minisketch_compute_max_elements(). */
+    static size_t ComputeMaxElements(uint32_t bits, size_t capacity, uint32_t fpbits) noexcept { return minisketch_compute_max_elements(bits, capacity, fpbits); }
+
+    /** Construct a clone of the specified sketch. */
+    Minisketch(const Minisketch& sketch) noexcept
+    {
+        m_minisketch = std::unique_ptr<minisketch, Deleter>(minisketch_clone(sketch.m_minisketch.get()));
+    }
+
+    /** Make this Minisketch a clone of the specified one. */
+    Minisketch& operator=(const Minisketch& sketch) noexcept
+    {
+        m_minisketch = std::unique_ptr<minisketch, Deleter>(minisketch_clone(sketch.m_minisketch.get()));
+        return *this;
+    }
+
+    explicit operator bool() const noexcept { return bool{m_minisketch}; }
+
+    Minisketch() noexcept = default;
+    Minisketch(Minisketch&&) noexcept = default;
+    Minisketch& operator=(Minisketch&&) noexcept = default;
+
+    /** Construct a Minisketch object with the specified parameters. */
+    Minisketch(uint32_t bits, uint32_t implementation, size_t capacity) noexcept
+    {
+        m_minisketch = std::unique_ptr<minisketch, Deleter>(minisketch_create(bits, implementation, capacity));
+    }
+
+    /** Create a Minisketch object sufficiently large for the specified number of elements at given fpbits. */
+    static Minisketch CreateFP(uint32_t bits, uint32_t implementation, size_t max_elements, uint32_t fpbits) noexcept
+    {
+        return Minisketch(bits, implementation, ComputeCapacity(bits, max_elements, fpbits));
+    }
+
+    /** See minisketch_get_bits(). */
+    uint32_t GetBits() const noexcept { return minisketch_bits(m_minisketch.get()); }
+
+    /** See minisketch_get_capacity(). */
+    size_t GetCapacity() const noexcept { return minisketch_capacity(m_minisketch.get()); }
+
+    /** See minisketch_get_implementation(). */
+    uint32_t GetImplementation() const noexcept { return minisketch_implementation(m_minisketch.get()); }
+
+    /** See minisketch_set_seed(). */
+    Minisketch& SetSeed(uint64_t seed) noexcept
+    {
+        minisketch_set_seed(m_minisketch.get(), seed);
+        return *this;
+    }
+
+    /** See miniksetch_add_element(). */
+    Minisketch& Add(uint64_t element) noexcept
+    {
+        minisketch_add_uint64(m_minisketch.get(), element);
+        return *this;
+    }
+
+    /** See minisketch_merge(). */
+    Minisketch& Merge(const Minisketch& sketch) noexcept
+    {
+        minisketch_merge(m_minisketch.get(), sketch.m_minisketch.get());
+        return *this;
+    }
+
+    /** Decode this sketch into the result vector, up to as many elements as the vector's size permits. */
+    bool Decode(std::vector<uint64_t>& result) const
+    {
+        ssize_t ret = minisketch_decode(m_minisketch.get(), result.size(), result.data());
+        if (ret == -1) return false;
+        result.resize(ret);
+        return true;
+    }
+
+    /** See minisketch_serialized_size(). */
+    size_t GetSerializedSize() const noexcept { return minisketch_serialized_size(m_minisketch.get()); }
+
+    /** Serialize the sketch as a byte vector. */
+    std::vector<unsigned char> Serialize() const
+    {
+        std::vector<unsigned char> result(GetSerializedSize());
+        minisketch_serialize(m_minisketch.get(), result.data());
+        return result;
+    }
+
+    /** Deserialize into this sketch from an object containing its bytes (which has data() and size() members). */
+    template<typename T>
+    Minisketch& Deserialize(
+        const T& obj,
+        typename std::enable_if<
+            std::is_convertible<typename std::remove_pointer<decltype(obj.data())>::type (*)[], const unsigned char (*)[]>::value &&
+            std::is_convertible<decltype(obj.size()), std::size_t>::value,
+            std::nullptr_t
+        >::type = nullptr) noexcept
+    {
+        assert(GetSerializedSize() == obj.size());
+        minisketch_deserialize(m_minisketch.get(), obj.data());
+        return *this;
+    }
+
+#if __cplusplus >= 201703L
+    /** C++17 only: decode up to a specified number of elements into an optional vector. */
+    std::optional<std::vector<uint64_t>> Decode(size_t max_elements) const
+    {
+        std::vector<uint64_t> result(max_elements);
+        ssize_t ret = minisketch_decode(m_minisketch.get(), max_elements, result.data());
+        if (ret == -1) return {};
+        result.resize(ret);
+        return std::move(result);
+    }
+
+    /** C++17 only: similar to Decode(), but with specified false positive probability. */
+    std::optional<std::vector<uint64_t>> DecodeFP(uint32_t fpbits) const
+    {
+        return Decode(ComputeMaxElements(GetBits(), GetCapacity(), fpbits));
+    }
+#endif // __cplusplus >= 201703L
+};
+#endif // __cplusplus >= 201103L
+#endif // __cplusplus
+
+#endif  // _MINISKETCH_H_

--- a/src/minisketch.cpp
+++ b/src/minisketch.cpp
@@ -133,6 +133,20 @@ uint32_t minisketch_implementation_max() {
     return ret;
 }
 
+int minisketch_implementation_supported(uint32_t bits, uint32_t implementation) {
+    if (!minisketch_bits_supported(bits) || implementation > minisketch_implementation_max()) {
+        return 0;
+    }
+    try {
+        Sketch* sketch = Construct(bits, implementation);
+        if (sketch) {
+            delete sketch;
+            return 1;
+        }
+    } catch (std::bad_alloc& ba) {}
+    return 0;
+}
+
 minisketch* minisketch_create(uint32_t bits, uint32_t implementation, size_t capacity) {
     if (capacity == 0) {
         return nullptr;

--- a/src/test-exhaust.cpp
+++ b/src/test-exhaust.cpp
@@ -25,7 +25,9 @@ uint64_t Combination(uint64_t n, uint64_t k) {
 }
 
 void TestAll(int bits, int impl, int count, uint32_t threadid, uint32_t threads, std::vector<uint64_t>& ret) {
+    bool supported = minisketch_implementation_supported(bits, impl);
     minisketch* state = minisketch_create(bits, impl, count);
+    CHECK(supported == (state != nullptr));
     if (!state) return;
 
     // Iterate over all (bits)-bit sketches with (count) syndromes.


### PR DESCRIPTION
This provides a safer API for use within C++ code. It's just a headers-only wrapper around the C API, so it does not introduce any further binary compatibility concerns.