### PR TITLE
Detect availability of intrinsics for clmul better 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,17 @@ AX_CHECK_COMPILE_FLAG([-Werror],[CXXFLAG_WERROR="-Werror"],[CXXFLAG_WERROR=""])
 
 AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory], [nodefault])
 enable_clmul=
-AX_CHECK_COMPILE_FLAG([-mpclmul],[[enable_clmul=yes]],,[[$CXXFLAG_WERROR]])
+AX_CHECK_COMPILE_FLAG([-mpclmul],[[enable_clmul=yes]],,[[$CXXFLAG_WERROR]],[AC_LANG_PROGRAM([
+  #include <stdint.h>
+  #include <x86intrin.h>
+], [
+  __m128i a = _mm_cvtsi64_si128((uint64_t)7);
+  __m128i b = _mm_clmulepi64_si128(a, a, 37);
+  __m128i c = _mm_srli_epi64(b, 41);
+  __m128i d = _mm_xor_si128(b, c);
+  uint64_t e = _mm_cvtsi128_si64(d);
+  return e == 0;
+])])
 if test x$enable_clmul = xyes; then
   CLMUL_CXXFLAGS="-mpclmul"
   AC_DEFINE(HAVE_CLMUL, 1, [Define this symbol if clmul instructions can be used])

--- a/sources.mk
+++ b/sources.mk
@@ -12,6 +12,7 @@ MINISKETCH_DIST_HEADERS_INT =
 MINISKETCH_DIST_HEADERS_INT += %reldir%/include/minisketch.h
 
 MINISKETCH_LIB_HEADERS_INT =
+MINISKETCH_LIB_HEADERS_INT += %reldir%/src/false_positives.h
 MINISKETCH_LIB_HEADERS_INT += %reldir%/src/int_utils.h
 MINISKETCH_LIB_HEADERS_INT += %reldir%/src/lintrans.h
 MINISKETCH_LIB_HEADERS_INT += %reldir%/src/sketch.h


### PR DESCRIPTION
The current configure.ac script only tests whether the compiler accepts the `-mpclmul` flag. This isn't sufficient: our clmul code for example also relies on SSE2 instructions (including ones that are only available on x86_64).

This results in the clmul based field implementations not being compiled on i686 anymore; they didn't work anyway (and fixing is more than a trivial amount of work).

Improve upon this by trying to actually compile a code snippet that exercises the intrinsics we need.