### PR TITLE
Avoid redundant std::move

### DIFF
--- a/include/minisketch.h
+++ b/include/minisketch.h
@@ -303,7 +303,7 @@ public:
         ssize_t ret = minisketch_decode(m_minisketch.get(), max_elements, result.data());
         if (ret == -1) return {};
         result.resize(ret);
-        return std::move(result);
+        return result;
     }
 
     /** C++17 only: similar to Decode(), but with specified false positive probability. */


### PR DESCRIPTION
I added this move initially because I believed the NVRO optimization didn't apply here (return type differs from variable type being returned). However, upon closer inspection this is not necessary: see "Automatic move from local variables and parameters" on https://en.cppreference.com/w/cpp/language/return, which states that even if the type differs, move-returning will be done if available.