### PR TITLE
Add support for 0 capacity sketches

### DIFF
--- a/include/minisketch.h
+++ b/include/minisketch.h
@@ -42,8 +42,8 @@ int minisketch_implementation_supported(uint32_t bits, uint32_t implementation);
 
 /** Construct a sketch for a given element size, implementation and capacity.
  *
- * If the combination of `bits` and `implementation` is unavailable, or if
- * `capacity` is 0, NULL is returned. If minisketch_implementation_supported
+ * If the combination of `bits` and `implementation` is unavailable, or when
+ * OOM occurs, NULL is returned. If minisketch_implementation_supported
  * returns 1 for the specified bits and implementation, this will always succeed
  * (except when allocation fails).
  *

--- a/src/minisketch.cpp
+++ b/src/minisketch.cpp
@@ -337,9 +337,6 @@ int minisketch_implementation_supported(uint32_t bits, uint32_t implementation) 
 }
 
 minisketch* minisketch_create(uint32_t bits, uint32_t implementation, size_t capacity) {
-    if (capacity == 0) {
-        return nullptr;
-    }
     try {
         Sketch* sketch = Construct(bits, implementation);
         if (sketch) {

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -123,7 +123,7 @@ void TestExhaustive(uint32_t bits, size_t capacity) {
 /** Test properties of sketches with random elements put in. */
 void TestRandomized(uint32_t bits, size_t max_capacity, size_t iter) {
     std::random_device rnd;
-    std::uniform_int_distribution<uint64_t> capacity_dist(1, std::min<uint64_t>(std::numeric_limits<uint64_t>::max() >> (64 - bits), max_capacity));
+    std::uniform_int_distribution<uint64_t> capacity_dist(0, std::min<uint64_t>(std::numeric_limits<uint64_t>::max() >> (64 - bits), max_capacity));
     std::uniform_int_distribution<uint64_t> element_dist(1, std::numeric_limits<uint64_t>::max() >> (64 - bits));
     std::uniform_int_distribution<uint64_t> rand64(0, std::numeric_limits<uint64_t>::max());
     std::uniform_int_distribution<int64_t> size_offset_dist(-3, 3);
@@ -298,8 +298,11 @@ int main(int argc, char** argv) {
         TestRandomized(j, 4096, test_complexity / j);
     }
 
-    for (int weight = 2; weight <= 40; ++weight) {
-        for (int bits = 2; bits <= 32 && bits <= weight; ++bits) {
+    // Test capacity==0 together with all field sizes, and then
+    // all combinations of bits and capacity up to a certain bits*capacity,
+    // depending on test_complexity.
+    for (int weight = 0; weight <= 40; ++weight) {
+        for (int bits = 2; weight == 0 ? bits <= 64 : (bits <= 32 && bits <= weight); ++bits) {
             int capacity = weight / bits;
             if (capacity * bits != weight) continue;
             TestExhaustive(bits, capacity);


### PR DESCRIPTION
Make `minisketch_create` return a functioning `minisketch*` when capacity=0 is passed, to remove the need for dealing with this edge case from the user.

See https://github.com/bitcoin/bitcoin/pull/21859#issuecomment-835937493 for discussion.