### PR TITLE
ci: update brew before installing packages

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -114,6 +114,7 @@ task:
     - env:
         CC: clang
   brew_script:
+    - brew update
     - brew install automake libtool gcc@9
   << : *MERGE_BASE
   test_script:


### PR DESCRIPTION
Given an older base image is being used, this can avoid instances where package installs fail, due to brew trying to use no-longer existent download locations.

Will see how long the update step takes, although a few minutes extra time spent in the macOS CI is probably less of an issue here. If it seems too long, I think moving to the Big Sur image would also be fine. 