### PR TITLE
Fix exhaustive test check

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -42,7 +42,7 @@ env_matrix_snippet: &ENV_MATRIX_SAN
   - env:
       BUILD: distcheck
   - env:
-      CFLAGS:  "-fsanitize=undefined -fno-omit-frame-pointer"
+      CXXFLAGS:  "-fsanitize=undefined -fno-omit-frame-pointer"
       LDFLAGS: "-fsanitize=undefined -fno-omit-frame-pointer"
       UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1"
       BENCH: no
@@ -57,7 +57,7 @@ env_matrix_snippet: &ENV_MATRIX_SAN_VALGRIND
       TESTRUNS: 1
       BUILD:
   - env:
-      CFLAGS:  "-fsanitize=undefined -fno-omit-frame-pointer"
+      CXXFLAGS:  "-fsanitize=undefined -fno-omit-frame-pointer"
       LDFLAGS: "-fsanitize=undefined -fno-omit-frame-pointer"
       UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1"
       BENCH: no

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -109,14 +109,15 @@ void TestExhaustive(uint32_t bits, size_t capacity) {
                 // Compare
                 CHECK(serialized == serialized_rebuild);
                 // Count it
-                if (elements_0.size() <= capacity) ++counts[elements_0.size()];
+                if (impl == 0 && elements_0.size() <= capacity) ++counts[elements_0.size()];
             }
         }
     }
 
     // Verify that the number of decodable sketches with given elements is expected.
-    for (uint64_t i = 0; i <= capacity && i >> bits; ++i) {
-        CHECK(counts[i] == Combination((uint64_t{1} << bits) - 1, i));
+    uint64_t mask = bits == 64 ? UINT64_MAX : (uint64_t{1} << bits) - 1;
+    for (uint64_t i = 0; i <= capacity && (i & mask) == i; ++i) {
+        CHECK(counts[i] == Combination(mask, i));
     }
 }
 


### PR DESCRIPTION
There were 3 issues:

1. The comparison between `counts[...]` and `Combination()` wasn't running at all (`(i >> bits)` is always 0 for i==0, so the loop would instantly exit).
2. The `counts` values were wrong (because it was counting a sum across all implementation), so if they would be compared to something, the test would incorrectly fail.
3. `(i >> bits)` is undefined when bits==64.

(1) would be fixed by changing `i >> bits` to `(i >> bits) == 0`, but that leaves issue (3), so introduce a `mask` and use a different way of writing the same, that keeps working for bits==64. (2) is fixed by only incrementing counts[...] for impl==0.

This was discovered through #50.