### PR TITLE
build: add MINISKETCH_INCLUDE_DIR_INT variable

### DIFF
--- a/sources.mk
+++ b/sources.mk
@@ -8,6 +8,8 @@
 #   downstreams to use these variables without having to manually account for
 #   the path change.
 
+MINISKETCH_INCLUDE_DIR_INT = %reldir%/include
+
 MINISKETCH_DIST_HEADERS_INT =
 MINISKETCH_DIST_HEADERS_INT += %reldir%/include/minisketch.h
 


### PR DESCRIPTION
Just a convenient way for downstream projects to use the include dir. Similar to what we have in the Univalue subtree now. 

cc theuni 