### PR TITLE
msvc: remove direct Bitcoin Core `compat.h` include

### DIFF
--- a/include/minisketch.h
+++ b/include/minisketch.h
@@ -5,7 +5,8 @@
 #include <stdlib.h>
 
 #ifdef _MSC_VER
-#  include <compat.h>
+#  include <BaseTsd.h>
+   typedef SSIZE_T ssize_t;
 #else
 #  include <unistd.h>
 #endif


### PR DESCRIPTION
My (untested) assumption is that this was only being used for a ssize_t
definition. Remove the include, and define ssize_t to SSIZE_T.

I'm planning on making a similar change in the Core codebase, and will pull a subtree update if this is merged.

See:
https://docs.microsoft.com/en-us/windows/win32/winprog/windows-data-types#ssize_t