### PR TITLE
Add missed `#include <string>`

### DIFF
--- a/src/test.cpp
+++ b/src/test.cpp
@@ -9,6 +9,7 @@
 #include <limits>
 #include <random>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 #include "../include/minisketch.h"


### PR DESCRIPTION
Required for `std::stoll`.

Otherwise, MSVC compiler fails to build the `test.exe` binary with errors as follows:
```
C:\Users\hebasto\minisketch\src\test.cpp(276,41): error C2039: 'stoll': is not a member of 'std'
C:\Users\hebasto\minisketch\src\test.cpp(276,46): error C3861: 'stoll': identifier not found
```