### PR TITLE
build: Remove `-Qunused-arguments` workaround for clang + ccache

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -124,9 +124,6 @@ if test "x$use_ccache" != "xno"; then
   fi
   AC_MSG_RESULT($use_ccache)
 fi
-if test "x$use_ccache" = "xyes"; then
-    AX_CHECK_COMPILE_FLAG([-Qunused-arguments],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Qunused-arguments"],,[[$CXXFLAG_WERROR]])
-fi
 
 VERIFY_DEFINES=-DMINISKETCH_VERIFY
 RELEASE_DEFINES=


### PR DESCRIPTION
The issue was addressed in [ccache 3.2](https://bugzilla.samba.org/show_bug.cgi?id=8118), and from a look at most major distros, it's only Debian Jessie that has a version of ccache older than that ([3.1](https://repology.org/project/ccache/versions)).

Therefore I think it's acceptable to drop this workaround, and re-enable warnings for unused driver arguments (when compiling using Clang and ccache).

This description quoted from https://github.com/bitcoin/bitcoin/pull/18535.