### PR TITLE
Enable codebase-wide `-Wshift-count-overflow` warning

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -104,11 +104,6 @@ esac
 AX_CHECK_COMPILE_FLAG([-Wall],[WARN_CXXFLAGS="$WARN_CXXFLAGS -Wall"],,[[$CXXFLAG_WERROR]])
 AX_CHECK_COMPILE_FLAG([-fvisibility=hidden],[CXXFLAGS="$CXXFLAGS -fvisibility=hidden"],[],[$CXXFLAG_WERROR])
 
-## Some compilers (gcc) ignore unknown -Wno-* options, but warn about all
-## unknown options if any other warning is produced. Test the -Wfoo case, and
-## set the -Wno-foo case if it works.
-AX_CHECK_COMPILE_FLAG([-Wshift-count-overflow],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-shift-count-overflow"],,[[$CXXFLAG_WERROR]])
-
 if test "x$use_ccache" != "xno"; then
   AC_MSG_CHECKING(if ccache should be used)
   if test x$CCACHE = x; then

--- a/src/int_utils.h
+++ b/src/int_utils.h
@@ -70,7 +70,14 @@ public:
         }
         while (bits >= 8) {
             *(out++) = val & 255;
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshift-count-overflow"
+#endif
             val >>= 8;
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
             bits -= 8;
         }
         state |= ((val & ((I(1) << bits) - 1)) << offset);


### PR DESCRIPTION
Instead of disabling a compiler warning for the entire codebase, it is safer to disable it for a single line of code.