### PR TITLE
Fix MSVC implementation of `CountBits()` function

### DIFF
--- a/src/int_utils.h
+++ b/src/int_utils.h
@@ -149,7 +149,7 @@ static inline int CountBits(I val, int max) {
         ret = _BitScanReverse64(&index, val);
     }
     if (!ret) return 0;
-    return index;
+    return index + 1;
 #else
     while (max && (val >> (max - 1) == 0)) --max;
     return max;

--- a/src/int_utils.h
+++ b/src/int_utils.h
@@ -129,17 +129,7 @@ constexpr inline I Mask() { return ((I((I(-1)) << (std::numeric_limits<I>::digit
 /** Compute the smallest power of two that is larger than val. */
 template<typename I>
 static inline int CountBits(I val, int max) {
-#ifdef HAVE_CLZ
-    (void)max;
-    if (val == 0) return 0;
-    if (std::numeric_limits<unsigned>::digits >= std::numeric_limits<I>::digits) {
-        return std::numeric_limits<unsigned>::digits - __builtin_clz(val);
-    } else if (std::numeric_limits<unsigned long>::digits >= std::numeric_limits<I>::digits) {
-        return std::numeric_limits<unsigned long>::digits - __builtin_clzl(val);
-    } else {
-        return std::numeric_limits<unsigned long long>::digits - __builtin_clzll(val);
-    }
-#elif _MSC_VER
+#ifdef _MSC_VER
     (void)max;
     unsigned long index;
     unsigned char ret;
@@ -150,6 +140,16 @@ static inline int CountBits(I val, int max) {
     }
     if (!ret) return 0;
     return index + 1;
+#elif HAVE_CLZ
+    (void)max;
+    if (val == 0) return 0;
+    if (std::numeric_limits<unsigned>::digits >= std::numeric_limits<I>::digits) {
+        return std::numeric_limits<unsigned>::digits - __builtin_clz(val);
+    } else if (std::numeric_limits<unsigned long>::digits >= std::numeric_limits<I>::digits) {
+        return std::numeric_limits<unsigned long>::digits - __builtin_clzl(val);
+    } else {
+        return std::numeric_limits<unsigned long long>::digits - __builtin_clzll(val);
+    }
 #else
     while (max && (val >> (max - 1) == 0)) --max;
     return max;


### PR DESCRIPTION
The current MSVC-specific implementation of the `CountBits()` function, which uses `_BitScanReverse` and `_BitScanReverse64` intrinsic functions, returns the wrong value with offset 1.

See: https://learn.microsoft.com/en-us/cpp/intrinsics/bitscanreverse-bitscanreverse64?view=msvc-170

The second commit makes MSVC ignore a possible `/DHAVE_CLZ` option (as this compiler is not handled by the current build system), which otherwise causes a compiling error.

A branch, which allows to test this PR easily, is [here](https://github.com/hebasto/minisketch/commits/221018-bits.test).

Fixes #67.