### PR TITLE
Add missing include

### DIFF
--- a/src/int_utils.h
+++ b/src/int_utils.h
@@ -7,6 +7,7 @@
 #ifndef _MINISKETCH_INT_UTILS_H_
 #define _MINISKETCH_INT_UTILS_H_
 
+#include <stdint.h>
 #include <stdlib.h>
 
 #include <limits>


### PR DESCRIPTION
stdint is needed for uint64_t and friends. Discovered when testing pre-compiled headers, which disturbs usual include ordering.

The problem can be seen with the simple testcase:
```c++
#include "int_utils.h"
int main(){}
```