### PR TITLE
build: Add `-Wundef`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -102,6 +102,7 @@ case $host in
 esac
 
 AX_CHECK_COMPILE_FLAG([-Wall],[WARN_CXXFLAGS="$WARN_CXXFLAGS -Wall"],,[[$CXXFLAG_WERROR]])
+AX_CHECK_COMPILE_FLAG([-Wundef], [WARN_CXXFLAGS="$WARN_CXXFLAGS -Wundef"], [], [$CXXFLAG_WERROR])
 AX_CHECK_COMPILE_FLAG([-fvisibility=hidden],[CXXFLAGS="$CXXFLAGS -fvisibility=hidden"],[],[$CXXFLAG_WERROR])
 
 if test "x$use_ccache" != "xno"; then

--- a/src/int_utils.h
+++ b/src/int_utils.h
@@ -159,7 +159,7 @@ static inline int CountBits(I val, int max) {
     }
     if (!ret) return 0;
     return index + 1;
-#elif HAVE_CLZ
+#elif defined(HAVE_CLZ)
     (void)max;
     if (val == 0) return 0;
     if (std::numeric_limits<unsigned>::digits >= std::numeric_limits<I>::digits) {


### PR DESCRIPTION
This PR addresses https://github.com/bitcoin/bitcoin/pull/29876#issuecomment-2157739910:

Steps to reproduce an issue:
```
$ g++ -Wundef -Wno-unused-parameter -o src/fields/libminisketch_a-generic_4bytes.o -c src/fields/generic_4bytes.cpp
In file included from src/fields/generic_common_impl.h:12,
                 from src/fields/generic_4bytes.cpp:12:
src/fields/../int_utils.h:162:7: warning: "HAVE_CLZ" is not defined, evaluates to 0 [-Wundef]
  162 | #elif HAVE_CLZ
      |       ^~~~~~~~
```