### PR TITLE
header: Delete default Minisketch constructor

### DIFF
--- a/include/minisketch.h
+++ b/include/minisketch.h
@@ -248,8 +248,8 @@ public:
     /** Check whether this Minisketch object is valid. */
     explicit operator bool() const noexcept { return bool{m_minisketch}; }
 
-    /** Construct an (invalid) Minisketch object. */
-    Minisketch() noexcept = default;
+    /** Default constructor is deleted. */
+    Minisketch() noexcept = delete;
 
     /** Move constructor. */
     Minisketch(Minisketch&&) noexcept = default;


### PR DESCRIPTION
I might be missing a reason for having the default constructor, but it is not used anywhere and trying to use one of its methods will cause a segfault.