### PR TITLE
feat(build): improve dependency check and error message in autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -10,6 +10,6 @@ if [ -z ${LIBTOOLIZE} ] && GLIBTOOLIZE="`which glibtoolize 2>/dev/null`"; then
   LIBTOOLIZE="${GLIBTOOLIZE}"
   export LIBTOOLIZE
 fi
-which autoreconf >/dev/null || \
+command -v autoreconf >/dev/null || \
   (echo "configuration failed, please install autoconf first" >&2 && exit 1)
 autoreconf --install --force --warnings=all

--- a/autogen.sh
+++ b/autogen.sh
@@ -11,5 +11,5 @@ if [ -z ${LIBTOOLIZE} ] && GLIBTOOLIZE="`which glibtoolize 2>/dev/null`"; then
   export LIBTOOLIZE
 fi
 which autoreconf >/dev/null || \
-  (echo "configuration failed, please install autoconf first" && exit 1)
+  (echo "configuration failed, please install autoconf first" >&2 && exit 1)
 autoreconf --install --force --warnings=all


### PR DESCRIPTION
Improve error reporting in `autogen.sh` by redirecting the autoreconf dependency check's error message to stderr.

Also use `command -v` instead of `which` in the script.

## Impact

This PR modifies `autogen.sh` in the root directory.

- No change to the functional behavior of these files.
- Enhances error reporting by directing error messages to stderr, aligning with best practices.
- Improves portability/reliability by using `command -v` instead of `which`. ([Link to ShellCheck rule](https://www.shellcheck.net/wiki/SC2230) for context.

## Background

**5 years ago:** Created the entire file with no other updates.

   - [Link to commit](https://github.com/sipa/minisketch/commit/7a0588140f3fc675b2be56d1fc8112ff8ca1bc96) to that commit.
