### PR TITLE
Make all non-test randomness user-provided

### DIFF
--- a/include/minisketch.h
+++ b/include/minisketch.h
@@ -60,16 +60,19 @@ MINISKETCH_API uint32_t minisketch_implementation_max(void);
  */
 MINISKETCH_API int minisketch_implementation_supported(uint32_t bits, uint32_t implementation);
 
-/** Construct a sketch for a given element size, implementation and capacity.
+/** Construct a sketch for a given element size, implementation, capacity, and RNG seed.
  *
  * If the combination of `bits` and `implementation` is unavailable, or when
  * OOM occurs, NULL is returned. If minisketch_implementation_supported
  * returns 1 for the specified bits and implementation, this will always succeed
  * (except when allocation fails).
  *
+ * To protect against bad performance on maliciously-created sketches, it is
+ * to use strong randomness for the provided seed value.
+ *
  * If the result is not NULL, it must be destroyed using minisketch_destroy.
  */
-MINISKETCH_API minisketch* minisketch_create(uint32_t bits, uint32_t implementation, size_t capacity);
+MINISKETCH_API minisketch* minisketch_create(uint32_t bits, uint32_t implementation, size_t capacity, uint64_t seed);
 
 /** Get the element size of a sketch in bits. */
 MINISKETCH_API uint32_t minisketch_bits(const minisketch* sketch);
@@ -82,14 +85,11 @@ MINISKETCH_API uint32_t minisketch_implementation(const minisketch* sketch);
 
 /** Set the seed for randomizing algorithm choices to a fixed value.
  *
- * By default, sketches are initialized with a random seed. This is important
- * to avoid scenarios where an attacker could force worst-case behavior.
- *
- * This function initializes the seed to a user-provided value (any 64-bit
- * integer is acceptable, regardless of field size).
+ * This is equivalent to recreating the sketch with a different RNG seed.
  *
  * When seed is -1, a fixed internal value with predictable behavior is
- * used. It is only intended for testing.
+ * used. It is only intended for testing. Note that minisketch_create does
+ * assign special meaning to seed = -1.
  */
 MINISKETCH_API void minisketch_set_seed(minisketch* sketch, uint64_t seed);
 
@@ -263,16 +263,16 @@ public:
      * ImplementationSupported(), or OOM occurs internally, an invalid Minisketch
      * object will be constructed. Use operator bool() to check that this isn't the
      * case before performing any other operations. */
-    Minisketch(uint32_t bits, uint32_t implementation, size_t capacity) noexcept
+    Minisketch(uint32_t bits, uint32_t implementation, size_t capacity, uint64_t seed) noexcept
     {
-        m_minisketch = std::unique_ptr<minisketch, Deleter>(minisketch_create(bits, implementation, capacity));
+        m_minisketch = std::unique_ptr<minisketch, Deleter>(minisketch_create(bits, implementation, capacity, seed));
     }
 
     /** Create a Minisketch object sufficiently large for the specified number of elements at given fpbits.
      *  It may construct an invalid object, which you may need to check for. */
-    static Minisketch CreateFP(uint32_t bits, uint32_t implementation, size_t max_elements, uint32_t fpbits) noexcept
+    static Minisketch CreateFP(uint32_t bits, uint32_t implementation, size_t max_elements, uint32_t fpbits, uint64_t seed) noexcept
     {
-        return Minisketch(bits, implementation, ComputeCapacity(bits, max_elements, fpbits));
+        return Minisketch(bits, implementation, ComputeCapacity(bits, max_elements, fpbits), seed);
     }
 
     /** Return the field size for a (valid) Minisketch object. */

--- a/src/bench.cpp
+++ b/src/bench.cpp
@@ -18,6 +18,8 @@ int main(int argc, char** argv) {
         printf("Usage: %s [syndromes=150] [errors=syndromes] [iters=10]\n", argv[0]);
         return 1;
     }
+    std::random_device rng;
+    std::uniform_int_distribution<uint64_t> dist;
     int syndromes = argc > 1 ? strtoul(argv[1], NULL, 10) : 150;
     int errors = argc > 2 ? strtoul(argv[2], NULL, 10) : syndromes;
     int iters = argc > 3 ? strtoul(argv[3], NULL, 10) : 10;
@@ -47,7 +49,7 @@ int main(int argc, char** argv) {
             std::vector<double> benches;
             benches.reserve(iters);
             for (int i = 0; i < iters; ++i) {
-                states[i] = minisketch_create(bits, impl, syndromes);
+                states[i] = minisketch_create(bits, impl, syndromes, dist(rng));
                 if (!states[i]) break;
                 std::set<uint64_t> done;
                 for (int j = 0; j < errors; ++j) {
@@ -80,15 +82,13 @@ int main(int argc, char** argv) {
         printf("create[ns]\t% 3i\t", bits);
         for (uint32_t impl = 0; impl <= max_impl; ++impl) {
             std::vector<minisketch*> states;
-            std::random_device rng;
-            std::uniform_int_distribution<uint64_t> dist;
             std::vector<uint64_t> data;
             data.resize(errors * 10);
             states.resize(iters);
             std::vector<double> benches;
             benches.reserve(iters);
             for (int i = 0; i < iters; ++i) {
-                states[i] = minisketch_create(bits, impl, syndromes);
+                states[i] = minisketch_create(bits, impl, syndromes, dist(rng));
             }
             for (size_t i = 0; i < data.size(); ++i) {
                 data[i] = dist(rng);

--- a/src/fields/clmul_1byte.cpp
+++ b/src/fields/clmul_1byte.cpp
@@ -82,37 +82,37 @@ typedef Field<uint8_t, 8, 27, StatTable8, &SQR_TABLE_8, &SQR2_TABLE_8, &QRT_TABL
 #endif
 }
 
-Sketch* ConstructClMul1Byte(int bits, int implementation) {
+Sketch* ConstructClMul1Byte(int bits, int implementation, uint64_t seed) {
     switch (bits) {
 #ifdef ENABLE_FIELD_INT_5
-    case 5: return new SketchImpl<Field5>(implementation, 5);
+    case 5: return new SketchImpl<Field5>(implementation, 5, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_8
-    case 8: return new SketchImpl<Field8>(implementation, 8);
+    case 8: return new SketchImpl<Field8>(implementation, 8, seed);
 #endif
     }
     return nullptr;
 }
 
-Sketch* ConstructClMulTri1Byte(int bits, int implementation) {
+Sketch* ConstructClMulTri1Byte(int bits, int implementation, uint64_t seed) {
     switch (bits) {
 #ifdef ENABLE_FIELD_INT_2
-    case 2: return new SketchImpl<FieldTri2>(implementation, 2);
+    case 2: return new SketchImpl<FieldTri2>(implementation, 2, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_3
-    case 3: return new SketchImpl<FieldTri3>(implementation, 3);
+    case 3: return new SketchImpl<FieldTri3>(implementation, 3, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_4
-    case 4: return new SketchImpl<FieldTri4>(implementation, 4);
+    case 4: return new SketchImpl<FieldTri4>(implementation, 4, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_5
-    case 5: return new SketchImpl<FieldTri5>(implementation, 5);
+    case 5: return new SketchImpl<FieldTri5>(implementation, 5, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_6
-    case 6: return new SketchImpl<FieldTri6>(implementation, 6);
+    case 6: return new SketchImpl<FieldTri6>(implementation, 6, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_7
-    case 7: return new SketchImpl<FieldTri7>(implementation, 7);
+    case 7: return new SketchImpl<FieldTri7>(implementation, 7, seed);
 #endif
     }
     return nullptr;

--- a/src/fields/clmul_2bytes.cpp
+++ b/src/fields/clmul_2bytes.cpp
@@ -105,49 +105,49 @@ typedef Field<uint16_t, 16, 43, StatTable16, &SQR_TABLE_16, &SQR2_TABLE_16, &SQR
 #endif
 }
 
-Sketch* ConstructClMul2Bytes(int bits, int implementation) {
+Sketch* ConstructClMul2Bytes(int bits, int implementation, uint64_t seed) {
     switch (bits) {
 #ifdef ENABLE_FIELD_INT_10
-    case 10: return new SketchImpl<Field10>(implementation, 10);
+    case 10: return new SketchImpl<Field10>(implementation, 10, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_11
-    case 11: return new SketchImpl<Field11>(implementation, 11);
+    case 11: return new SketchImpl<Field11>(implementation, 11, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_12
-    case 12: return new SketchImpl<Field12>(implementation, 12);
+    case 12: return new SketchImpl<Field12>(implementation, 12, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_13
-    case 13: return new SketchImpl<Field13>(implementation, 13);
+    case 13: return new SketchImpl<Field13>(implementation, 13, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_14
-    case 14: return new SketchImpl<Field14>(implementation, 14);
+    case 14: return new SketchImpl<Field14>(implementation, 14, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_16
-    case 16: return new SketchImpl<Field16>(implementation, 16);
+    case 16: return new SketchImpl<Field16>(implementation, 16, seed);
 #endif
     }
     return nullptr;
 }
 
-Sketch* ConstructClMulTri2Bytes(int bits, int implementation) {
+Sketch* ConstructClMulTri2Bytes(int bits, int implementation, uint64_t seed) {
     switch (bits) {
 #ifdef ENABLE_FIELD_INT_9
-    case 9: return new SketchImpl<FieldTri9>(implementation, 9);
+    case 9: return new SketchImpl<FieldTri9>(implementation, 9, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_10
-    case 10: return new SketchImpl<FieldTri10>(implementation, 10);
+    case 10: return new SketchImpl<FieldTri10>(implementation, 10, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_11
-    case 11: return new SketchImpl<FieldTri11>(implementation, 11);
+    case 11: return new SketchImpl<FieldTri11>(implementation, 11, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_12
-    case 12: return new SketchImpl<FieldTri12>(implementation, 12);
+    case 12: return new SketchImpl<FieldTri12>(implementation, 12, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_14
-    case 14: return new SketchImpl<FieldTri14>(implementation, 14);
+    case 14: return new SketchImpl<FieldTri14>(implementation, 14, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_15
-    case 15: return new SketchImpl<FieldTri15>(implementation, 15);
+    case 15: return new SketchImpl<FieldTri15>(implementation, 15, seed);
 #endif
     }
     return nullptr;

--- a/src/fields/clmul_3bytes.cpp
+++ b/src/fields/clmul_3bytes.cpp
@@ -114,52 +114,52 @@ typedef Field<uint32_t, 24, 27, StatTable24, &SQR_TABLE_24, &SQR2_TABLE_24, &SQR
 #endif
 }
 
-Sketch* ConstructClMul3Bytes(int bits, int implementation) {
+Sketch* ConstructClMul3Bytes(int bits, int implementation, uint64_t seed) {
     switch (bits) {
 #ifdef ENABLE_FIELD_INT_17
-    case 17: return new SketchImpl<Field17>(implementation, 17);
+    case 17: return new SketchImpl<Field17>(implementation, 17, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_18
-    case 18: return new SketchImpl<Field18>(implementation, 18);
+    case 18: return new SketchImpl<Field18>(implementation, 18, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_19
-    case 19: return new SketchImpl<Field19>(implementation, 19);
+    case 19: return new SketchImpl<Field19>(implementation, 19, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_20
-    case 20: return new SketchImpl<Field20>(implementation, 20);
+    case 20: return new SketchImpl<Field20>(implementation, 20, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_21
-    case 21: return new SketchImpl<Field21>(implementation, 21);
+    case 21: return new SketchImpl<Field21>(implementation, 21, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_23
-    case 23: return new SketchImpl<Field23>(implementation, 23);
+    case 23: return new SketchImpl<Field23>(implementation, 23, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_24
-    case 24: return new SketchImpl<Field24>(implementation, 24);
+    case 24: return new SketchImpl<Field24>(implementation, 24, seed);
 #endif
     }
     return nullptr;
 }
 
-Sketch* ConstructClMulTri3Bytes(int bits, int implementation) {
+Sketch* ConstructClMulTri3Bytes(int bits, int implementation, uint64_t seed) {
     switch (bits) {
 #ifdef ENABLE_FIELD_INT_17
-    case 17: return new SketchImpl<FieldTri17>(implementation, 17);
+    case 17: return new SketchImpl<FieldTri17>(implementation, 17, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_18
-    case 18: return new SketchImpl<FieldTri18>(implementation, 18);
+    case 18: return new SketchImpl<FieldTri18>(implementation, 18, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_20
-    case 20: return new SketchImpl<FieldTri20>(implementation, 20);
+    case 20: return new SketchImpl<FieldTri20>(implementation, 20, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_21
-    case 21: return new SketchImpl<FieldTri21>(implementation, 21);
+    case 21: return new SketchImpl<FieldTri21>(implementation, 21, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_22
-    case 22: return new SketchImpl<FieldTri22>(implementation, 22);
+    case 22: return new SketchImpl<FieldTri22>(implementation, 22, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_23
-    case 23: return new SketchImpl<FieldTri23>(implementation, 23);
+    case 23: return new SketchImpl<FieldTri23>(implementation, 23, seed);
 #endif
     }
     return nullptr;

--- a/src/fields/clmul_4bytes.cpp
+++ b/src/fields/clmul_4bytes.cpp
@@ -112,46 +112,46 @@ typedef Field<uint32_t, 32, 141, StatTable32, &SQR_TABLE_32, &SQR2_TABLE_32, &SQ
 #endif
 }
 
-Sketch* ConstructClMul4Bytes(int bits, int implementation) {
+Sketch* ConstructClMul4Bytes(int bits, int implementation, uint64_t seed) {
     switch (bits) {
 #ifdef ENABLE_FIELD_INT_25
-    case 25: return new SketchImpl<Field25>(implementation, 25);
+    case 25: return new SketchImpl<Field25>(implementation, 25, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_26
-    case 26: return new SketchImpl<Field26>(implementation, 26);
+    case 26: return new SketchImpl<Field26>(implementation, 26, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_27
-    case 27: return new SketchImpl<Field27>(implementation, 27);
+    case 27: return new SketchImpl<Field27>(implementation, 27, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_29
-    case 29: return new SketchImpl<Field29>(implementation, 29);
+    case 29: return new SketchImpl<Field29>(implementation, 29, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_31
-    case 31: return new SketchImpl<Field31>(implementation, 31);
+    case 31: return new SketchImpl<Field31>(implementation, 31, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_32
-    case 32: return new SketchImpl<Field32>(implementation, 32);
+    case 32: return new SketchImpl<Field32>(implementation, 32, seed);
 #endif
     }
     return nullptr;
 }
 
-Sketch* ConstructClMulTri4Bytes(int bits, int implementation) {
+Sketch* ConstructClMulTri4Bytes(int bits, int implementation, uint64_t seed) {
     switch (bits) {
 #ifdef ENABLE_FIELD_INT_25
-    case 25: return new SketchImpl<FieldTri25>(implementation, 25);
+    case 25: return new SketchImpl<FieldTri25>(implementation, 25, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_28
-    case 28: return new SketchImpl<FieldTri28>(implementation, 28);
+    case 28: return new SketchImpl<FieldTri28>(implementation, 28, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_29
-    case 29: return new SketchImpl<FieldTri29>(implementation, 29);
+    case 29: return new SketchImpl<FieldTri29>(implementation, 29, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_30
-    case 30: return new SketchImpl<FieldTri30>(implementation, 30);
+    case 30: return new SketchImpl<FieldTri30>(implementation, 30, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_31
-    case 31: return new SketchImpl<FieldTri31>(implementation, 31);
+    case 31: return new SketchImpl<FieldTri31>(implementation, 31, seed);
 #endif
     }
     return nullptr;

--- a/src/fields/clmul_5bytes.cpp
+++ b/src/fields/clmul_5bytes.cpp
@@ -122,52 +122,52 @@ typedef Field<uint64_t, 40, 57, StatTable40, &SQR_TABLE_40, &SQR2_TABLE_40, &SQR
 #endif
 }
 
-Sketch* ConstructClMul5Bytes(int bits, int implementation) {
+Sketch* ConstructClMul5Bytes(int bits, int implementation, uint64_t seed) {
     switch (bits) {
 #ifdef ENABLE_FIELD_INT_33
-    case 33: return new SketchImpl<Field33>(implementation, 33);
+    case 33: return new SketchImpl<Field33>(implementation, 33, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_34
-    case 34: return new SketchImpl<Field34>(implementation, 34);
+    case 34: return new SketchImpl<Field34>(implementation, 34, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_35
-    case 35: return new SketchImpl<Field35>(implementation, 35);
+    case 35: return new SketchImpl<Field35>(implementation, 35, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_36
-    case 36: return new SketchImpl<Field36>(implementation, 36);
+    case 36: return new SketchImpl<Field36>(implementation, 36, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_37
-    case 37: return new SketchImpl<Field37>(implementation, 37);
+    case 37: return new SketchImpl<Field37>(implementation, 37, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_38
-    case 38: return new SketchImpl<Field38>(implementation, 38);
+    case 38: return new SketchImpl<Field38>(implementation, 38, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_39
-    case 39: return new SketchImpl<Field39>(implementation, 39);
+    case 39: return new SketchImpl<Field39>(implementation, 39, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_40
-    case 40: return new SketchImpl<Field40>(implementation, 40);
+    case 40: return new SketchImpl<Field40>(implementation, 40, seed);
 #endif
     }
     return nullptr;
 }
 
-Sketch* ConstructClMulTri5Bytes(int bits, int implementation) {
+Sketch* ConstructClMulTri5Bytes(int bits, int implementation, uint64_t seed) {
     switch (bits) {
 #ifdef ENABLE_FIELD_INT_33
-    case 33: return new SketchImpl<FieldTri33>(implementation, 33);
+    case 33: return new SketchImpl<FieldTri33>(implementation, 33, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_34
-    case 34: return new SketchImpl<FieldTri34>(implementation, 34);
+    case 34: return new SketchImpl<FieldTri34>(implementation, 34, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_35
-    case 35: return new SketchImpl<FieldTri35>(implementation, 35);
+    case 35: return new SketchImpl<FieldTri35>(implementation, 35, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_36
-    case 36: return new SketchImpl<FieldTri36>(implementation, 36);
+    case 36: return new SketchImpl<FieldTri36>(implementation, 36, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_39
-    case 39: return new SketchImpl<FieldTri39>(implementation, 39);
+    case 39: return new SketchImpl<FieldTri39>(implementation, 39, seed);
 #endif
     }
     return nullptr;

--- a/src/fields/clmul_6bytes.cpp
+++ b/src/fields/clmul_6bytes.cpp
@@ -121,49 +121,49 @@ typedef Field<uint64_t, 48, 45, StatTable48, &SQR_TABLE_48, &SQR2_TABLE_48, &SQR
 #endif
 }
 
-Sketch* ConstructClMul6Bytes(int bits, int implementation) {
+Sketch* ConstructClMul6Bytes(int bits, int implementation, uint64_t seed) {
     switch (bits) {
 #ifdef ENABLE_FIELD_INT_41
-    case 41: return new SketchImpl<Field41>(implementation, 41);
+    case 41: return new SketchImpl<Field41>(implementation, 41, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_42
-    case 42: return new SketchImpl<Field42>(implementation, 42);
+    case 42: return new SketchImpl<Field42>(implementation, 42, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_43
-    case 43: return new SketchImpl<Field43>(implementation, 43);
+    case 43: return new SketchImpl<Field43>(implementation, 43, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_44
-    case 44: return new SketchImpl<Field44>(implementation, 44);
+    case 44: return new SketchImpl<Field44>(implementation, 44, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_45
-    case 45: return new SketchImpl<Field45>(implementation, 45);
+    case 45: return new SketchImpl<Field45>(implementation, 45, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_47
-    case 47: return new SketchImpl<Field47>(implementation, 47);
+    case 47: return new SketchImpl<Field47>(implementation, 47, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_48
-    case 48: return new SketchImpl<Field48>(implementation, 48);
+    case 48: return new SketchImpl<Field48>(implementation, 48, seed);
 #endif
     }
     return nullptr;
 }
 
-Sketch* ConstructClMulTri6Bytes(int bits, int implementation) {
+Sketch* ConstructClMulTri6Bytes(int bits, int implementation, uint64_t seed) {
     switch (bits) {
 #ifdef ENABLE_FIELD_INT_41
-    case 41: return new SketchImpl<FieldTri41>(implementation, 41);
+    case 41: return new SketchImpl<FieldTri41>(implementation, 41, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_42
-    case 42: return new SketchImpl<FieldTri42>(implementation, 42);
+    case 42: return new SketchImpl<FieldTri42>(implementation, 42, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_44
-    case 44: return new SketchImpl<FieldTri44>(implementation, 44);
+    case 44: return new SketchImpl<FieldTri44>(implementation, 44, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_46
-    case 46: return new SketchImpl<FieldTri46>(implementation, 46);
+    case 46: return new SketchImpl<FieldTri46>(implementation, 46, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_47
-    case 47: return new SketchImpl<FieldTri47>(implementation, 47);
+    case 47: return new SketchImpl<FieldTri47>(implementation, 47, seed);
 #endif
     }
     return nullptr;

--- a/src/fields/clmul_7bytes.cpp
+++ b/src/fields/clmul_7bytes.cpp
@@ -121,49 +121,49 @@ typedef Field<uint64_t, 56, 149, StatTable56, &SQR_TABLE_56, &SQR2_TABLE_56, &SQ
 #endif
 }
 
-Sketch* ConstructClMul7Bytes(int bits, int implementation) {
+Sketch* ConstructClMul7Bytes(int bits, int implementation, uint64_t seed) {
     switch (bits) {
 #ifdef ENABLE_FIELD_INT_49
-    case 49: return new SketchImpl<Field49>(implementation, 49);
+    case 49: return new SketchImpl<Field49>(implementation, 49, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_50
-    case 50: return new SketchImpl<Field50>(implementation, 50);
+    case 50: return new SketchImpl<Field50>(implementation, 50, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_51
-    case 51: return new SketchImpl<Field51>(implementation, 51);
+    case 51: return new SketchImpl<Field51>(implementation, 51, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_52
-    case 52: return new SketchImpl<Field52>(implementation, 52);
+    case 52: return new SketchImpl<Field52>(implementation, 52, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_53
-    case 53: return new SketchImpl<Field53>(implementation, 53);
+    case 53: return new SketchImpl<Field53>(implementation, 53, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_54
-    case 54: return new SketchImpl<Field54>(implementation, 54);
+    case 54: return new SketchImpl<Field54>(implementation, 54, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_55
-    case 55: return new SketchImpl<Field55>(implementation, 55);
+    case 55: return new SketchImpl<Field55>(implementation, 55, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_56
-    case 56: return new SketchImpl<Field56>(implementation, 56);
+    case 56: return new SketchImpl<Field56>(implementation, 56, seed);
 #endif
     }
     return nullptr;
 }
 
-Sketch* ConstructClMulTri7Bytes(int bits, int implementation) {
+Sketch* ConstructClMulTri7Bytes(int bits, int implementation, uint64_t seed) {
     switch (bits) {
 #ifdef ENABLE_FIELD_INT_49
-    case 49: return new SketchImpl<FieldTri49>(implementation, 49);
+    case 49: return new SketchImpl<FieldTri49>(implementation, 49, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_52
-    case 52: return new SketchImpl<FieldTri52>(implementation, 52);
+    case 52: return new SketchImpl<FieldTri52>(implementation, 52, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_54
-    case 54: return new SketchImpl<FieldTri54>(implementation, 54);
+    case 54: return new SketchImpl<FieldTri54>(implementation, 54, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_55
-    case 55: return new SketchImpl<FieldTri55>(implementation, 55);
+    case 55: return new SketchImpl<FieldTri55>(implementation, 55, seed);
 #endif
     }
     return nullptr;

--- a/src/fields/clmul_8bytes.cpp
+++ b/src/fields/clmul_8bytes.cpp
@@ -129,46 +129,46 @@ typedef Field<uint64_t, 64, 27, StatTable64, &SQR_TABLE_64, &SQR2_TABLE_64, &SQR
 #endif
 }
 
-Sketch* ConstructClMul8Bytes(int bits, int implementation) {
+Sketch* ConstructClMul8Bytes(int bits, int implementation, uint64_t seed) {
     switch (bits) {
 #ifdef ENABLE_FIELD_INT_57
-    case 57: return new SketchImpl<Field57>(implementation, 57);
+    case 57: return new SketchImpl<Field57>(implementation, 57, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_58
-    case 58: return new SketchImpl<Field58>(implementation, 58);
+    case 58: return new SketchImpl<Field58>(implementation, 58, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_59
-    case 59: return new SketchImpl<Field59>(implementation, 59);
+    case 59: return new SketchImpl<Field59>(implementation, 59, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_61
-    case 61: return new SketchImpl<Field61>(implementation, 61);
+    case 61: return new SketchImpl<Field61>(implementation, 61, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_62
-    case 62: return new SketchImpl<Field62>(implementation, 62);
+    case 62: return new SketchImpl<Field62>(implementation, 62, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_64
-    case 64: return new SketchImpl<Field64>(implementation, 64);
+    case 64: return new SketchImpl<Field64>(implementation, 64, seed);
 #endif
     }
     return nullptr;
 }
 
-Sketch* ConstructClMulTri8Bytes(int bits, int implementation) {
+Sketch* ConstructClMulTri8Bytes(int bits, int implementation, uint64_t seed) {
     switch (bits) {
 #ifdef ENABLE_FIELD_INT_57
-    case 57: return new SketchImpl<FieldTri57>(implementation, 57);
+    case 57: return new SketchImpl<FieldTri57>(implementation, 57, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_58
-    case 58: return new SketchImpl<FieldTri58>(implementation, 58);
+    case 58: return new SketchImpl<FieldTri58>(implementation, 58, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_60
-    case 60: return new SketchImpl<FieldTri60>(implementation, 60);
+    case 60: return new SketchImpl<FieldTri60>(implementation, 60, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_62
-    case 62: return new SketchImpl<FieldTri62>(implementation, 62);
+    case 62: return new SketchImpl<FieldTri62>(implementation, 62, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_63
-    case 63: return new SketchImpl<FieldTri63>(implementation, 63);
+    case 63: return new SketchImpl<FieldTri63>(implementation, 63, seed);
 #endif
     }
     return nullptr;

--- a/src/fields/generic_1byte.cpp
+++ b/src/fields/generic_1byte.cpp
@@ -83,29 +83,29 @@ typedef Field<uint8_t, 8, 27, StatTable8, DynTable8, &SQR_TABLE_8, &QRT_TABLE_8>
 #endif
 }
 
-Sketch* ConstructGeneric1Byte(int bits, int implementation)
+Sketch* ConstructGeneric1Byte(int bits, int implementation, uint64_t seed)
 {
     switch (bits) {
 #ifdef ENABLE_FIELD_INT_2
-    case 2: return new SketchImpl<Field2>(implementation, 2);
+    case 2: return new SketchImpl<Field2>(implementation, 2, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_3
-    case 3: return new SketchImpl<Field3>(implementation, 3);
+    case 3: return new SketchImpl<Field3>(implementation, 3, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_4
-    case 4: return new SketchImpl<Field4>(implementation, 4);
+    case 4: return new SketchImpl<Field4>(implementation, 4, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_5
-    case 5: return new SketchImpl<Field5>(implementation, 5);
+    case 5: return new SketchImpl<Field5>(implementation, 5, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_6
-    case 6: return new SketchImpl<Field6>(implementation, 6);
+    case 6: return new SketchImpl<Field6>(implementation, 6, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_7
-    case 7: return new SketchImpl<Field7>(implementation, 7);
+    case 7: return new SketchImpl<Field7>(implementation, 7, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_8
-    case 8: return new SketchImpl<Field8>(implementation, 8);
+    case 8: return new SketchImpl<Field8>(implementation, 8, seed);
 #endif
     default: return nullptr;
     }

--- a/src/fields/generic_2bytes.cpp
+++ b/src/fields/generic_2bytes.cpp
@@ -92,32 +92,32 @@ typedef Field<uint16_t, 16, 43, StatTable16, DynTable16, &SQR_TABLE_16, &QRT_TAB
 #endif
 }
 
-Sketch* ConstructGeneric2Bytes(int bits, int implementation)
+Sketch* ConstructGeneric2Bytes(int bits, int implementation, uint64_t seed)
 {
     switch (bits) {
 #ifdef ENABLE_FIELD_INT_9
-    case 9: return new SketchImpl<Field9>(implementation, 9);
+    case 9: return new SketchImpl<Field9>(implementation, 9, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_10
-    case 10: return new SketchImpl<Field10>(implementation, 10);
+    case 10: return new SketchImpl<Field10>(implementation, 10, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_11
-    case 11: return new SketchImpl<Field11>(implementation, 11);
+    case 11: return new SketchImpl<Field11>(implementation, 11, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_12
-    case 12: return new SketchImpl<Field12>(implementation, 12);
+    case 12: return new SketchImpl<Field12>(implementation, 12, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_13
-    case 13: return new SketchImpl<Field13>(implementation, 13);
+    case 13: return new SketchImpl<Field13>(implementation, 13, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_14
-    case 14: return new SketchImpl<Field14>(implementation, 14);
+    case 14: return new SketchImpl<Field14>(implementation, 14, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_15
-    case 15: return new SketchImpl<Field15>(implementation, 15);
+    case 15: return new SketchImpl<Field15>(implementation, 15, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_16
-    case 16: return new SketchImpl<Field16>(implementation, 16);
+    case 16: return new SketchImpl<Field16>(implementation, 16, seed);
 #endif
     default: return nullptr;
     }

--- a/src/fields/generic_3bytes.cpp
+++ b/src/fields/generic_3bytes.cpp
@@ -92,32 +92,32 @@ typedef Field<uint32_t, 24, 27, StatTable24, DynTable24, &SQR_TABLE_24, &QRT_TAB
 #endif
 }
 
-Sketch* ConstructGeneric3Bytes(int bits, int implementation)
+Sketch* ConstructGeneric3Bytes(int bits, int implementation, uint64_t seed)
 {
     switch (bits) {
 #ifdef ENABLE_FIELD_INT_17
-    case 17: return new SketchImpl<Field17>(implementation, 17);
+    case 17: return new SketchImpl<Field17>(implementation, 17, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_18
-    case 18: return new SketchImpl<Field18>(implementation, 18);
+    case 18: return new SketchImpl<Field18>(implementation, 18, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_19
-    case 19: return new SketchImpl<Field19>(implementation, 19);
+    case 19: return new SketchImpl<Field19>(implementation, 19, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_20
-    case 20: return new SketchImpl<Field20>(implementation, 20);
+    case 20: return new SketchImpl<Field20>(implementation, 20, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_21
-    case 21: return new SketchImpl<Field21>(implementation, 21);
+    case 21: return new SketchImpl<Field21>(implementation, 21, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_22
-    case 22: return new SketchImpl<Field22>(implementation, 22);
+    case 22: return new SketchImpl<Field22>(implementation, 22, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_23
-    case 23: return new SketchImpl<Field23>(implementation, 23);
+    case 23: return new SketchImpl<Field23>(implementation, 23, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_24
-    case 24: return new SketchImpl<Field24>(implementation, 24);
+    case 24: return new SketchImpl<Field24>(implementation, 24, seed);
 #endif
     default: return nullptr;
     }

--- a/src/fields/generic_4bytes.cpp
+++ b/src/fields/generic_4bytes.cpp
@@ -92,32 +92,32 @@ typedef Field<uint32_t, 32, 141, StatTable32, DynTable32, &SQR_TABLE_32, &QRT_TA
 #endif
 }
 
-Sketch* ConstructGeneric4Bytes(int bits, int implementation)
+Sketch* ConstructGeneric4Bytes(int bits, int implementation, uint64_t seed)
 {
     switch (bits) {
 #ifdef ENABLE_FIELD_INT_25
-    case 25: return new SketchImpl<Field25>(implementation, 25);
+    case 25: return new SketchImpl<Field25>(implementation, 25, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_26
-    case 26: return new SketchImpl<Field26>(implementation, 26);
+    case 26: return new SketchImpl<Field26>(implementation, 26, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_27
-    case 27: return new SketchImpl<Field27>(implementation, 27);
+    case 27: return new SketchImpl<Field27>(implementation, 27, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_28
-    case 28: return new SketchImpl<Field28>(implementation, 28);
+    case 28: return new SketchImpl<Field28>(implementation, 28, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_29
-    case 29: return new SketchImpl<Field29>(implementation, 29);
+    case 29: return new SketchImpl<Field29>(implementation, 29, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_30
-    case 30: return new SketchImpl<Field30>(implementation, 30);
+    case 30: return new SketchImpl<Field30>(implementation, 30, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_31
-    case 31: return new SketchImpl<Field31>(implementation, 31);
+    case 31: return new SketchImpl<Field31>(implementation, 31, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_32
-    case 32: return new SketchImpl<Field32>(implementation, 32);
+    case 32: return new SketchImpl<Field32>(implementation, 32, seed);
 #endif
     default: return nullptr;
     }

--- a/src/fields/generic_5bytes.cpp
+++ b/src/fields/generic_5bytes.cpp
@@ -92,32 +92,32 @@ typedef Field<uint64_t, 40, 57, StatTable40, DynTable40, &SQR_TABLE_40, &QRT_TAB
 #endif
 }
 
-Sketch* ConstructGeneric5Bytes(int bits, int implementation)
+Sketch* ConstructGeneric5Bytes(int bits, int implementation, uint64_t seed)
 {
     switch (bits) {
 #ifdef ENABLE_FIELD_INT_33
-    case 33: return new SketchImpl<Field33>(implementation, 33);
+    case 33: return new SketchImpl<Field33>(implementation, 33, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_34
-    case 34: return new SketchImpl<Field34>(implementation, 34);
+    case 34: return new SketchImpl<Field34>(implementation, 34, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_35
-    case 35: return new SketchImpl<Field35>(implementation, 35);
+    case 35: return new SketchImpl<Field35>(implementation, 35, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_36
-    case 36: return new SketchImpl<Field36>(implementation, 36);
+    case 36: return new SketchImpl<Field36>(implementation, 36, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_37
-    case 37: return new SketchImpl<Field37>(implementation, 37);
+    case 37: return new SketchImpl<Field37>(implementation, 37, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_38
-    case 38: return new SketchImpl<Field38>(implementation, 38);
+    case 38: return new SketchImpl<Field38>(implementation, 38, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_39
-    case 39: return new SketchImpl<Field39>(implementation, 39);
+    case 39: return new SketchImpl<Field39>(implementation, 39, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_40
-    case 40: return new SketchImpl<Field40>(implementation, 40);
+    case 40: return new SketchImpl<Field40>(implementation, 40, seed);
 #endif
     default: return nullptr;
     }

--- a/src/fields/generic_6bytes.cpp
+++ b/src/fields/generic_6bytes.cpp
@@ -92,32 +92,32 @@ typedef Field<uint64_t, 48, 45, StatTable48, DynTable48, &SQR_TABLE_48, &QRT_TAB
 #endif
 }
 
-Sketch* ConstructGeneric6Bytes(int bits, int implementation)
+Sketch* ConstructGeneric6Bytes(int bits, int implementation, uint64_t seed)
 {
     switch (bits) {
 #ifdef ENABLE_FIELD_INT_41
-    case 41: return new SketchImpl<Field41>(implementation, 41);
+    case 41: return new SketchImpl<Field41>(implementation, 41, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_42
-    case 42: return new SketchImpl<Field42>(implementation, 42);
+    case 42: return new SketchImpl<Field42>(implementation, 42, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_43
-    case 43: return new SketchImpl<Field43>(implementation, 43);
+    case 43: return new SketchImpl<Field43>(implementation, 43, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_44
-    case 44: return new SketchImpl<Field44>(implementation, 44);
+    case 44: return new SketchImpl<Field44>(implementation, 44, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_45
-    case 45: return new SketchImpl<Field45>(implementation, 45);
+    case 45: return new SketchImpl<Field45>(implementation, 45, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_46
-    case 46: return new SketchImpl<Field46>(implementation, 46);
+    case 46: return new SketchImpl<Field46>(implementation, 46, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_47
-    case 47: return new SketchImpl<Field47>(implementation, 47);
+    case 47: return new SketchImpl<Field47>(implementation, 47, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_48
-    case 48: return new SketchImpl<Field48>(implementation, 48);
+    case 48: return new SketchImpl<Field48>(implementation, 48, seed);
 #endif
     default: return nullptr;
     }

--- a/src/fields/generic_7bytes.cpp
+++ b/src/fields/generic_7bytes.cpp
@@ -92,32 +92,32 @@ typedef Field<uint64_t, 56, 149, StatTable56, DynTable56, &SQR_TABLE_56, &QRT_TA
 #endif
 }
 
-Sketch* ConstructGeneric7Bytes(int bits, int implementation)
+Sketch* ConstructGeneric7Bytes(int bits, int implementation, uint64_t seed)
 {
     switch (bits) {
 #ifdef ENABLE_FIELD_INT_49
-    case 49: return new SketchImpl<Field49>(implementation, 49);
+    case 49: return new SketchImpl<Field49>(implementation, 49, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_50
-    case 50: return new SketchImpl<Field50>(implementation, 50);
+    case 50: return new SketchImpl<Field50>(implementation, 50, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_51
-    case 51: return new SketchImpl<Field51>(implementation, 51);
+    case 51: return new SketchImpl<Field51>(implementation, 51, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_52
-    case 52: return new SketchImpl<Field52>(implementation, 52);
+    case 52: return new SketchImpl<Field52>(implementation, 52, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_53
-    case 53: return new SketchImpl<Field53>(implementation, 53);
+    case 53: return new SketchImpl<Field53>(implementation, 53, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_54
-    case 54: return new SketchImpl<Field54>(implementation, 54);
+    case 54: return new SketchImpl<Field54>(implementation, 54, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_55
-    case 55: return new SketchImpl<Field55>(implementation, 55);
+    case 55: return new SketchImpl<Field55>(implementation, 55, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_56
-    case 56: return new SketchImpl<Field56>(implementation, 56);
+    case 56: return new SketchImpl<Field56>(implementation, 56, seed);
 #endif
     default: return nullptr;
     }

--- a/src/fields/generic_8bytes.cpp
+++ b/src/fields/generic_8bytes.cpp
@@ -92,32 +92,32 @@ typedef Field<uint64_t, 64, 27, StatTable64, DynTable64, &SQR_TABLE_64, &QRT_TAB
 #endif
 }
 
-Sketch* ConstructGeneric8Bytes(int bits, int implementation)
+Sketch* ConstructGeneric8Bytes(int bits, int implementation, uint64_t seed)
 {
     switch (bits) {
 #ifdef ENABLE_FIELD_INT_57
-    case 57: return new SketchImpl<Field57>(implementation, 57);
+    case 57: return new SketchImpl<Field57>(implementation, 57, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_58
-    case 58: return new SketchImpl<Field58>(implementation, 58);
+    case 58: return new SketchImpl<Field58>(implementation, 58, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_59
-    case 59: return new SketchImpl<Field59>(implementation, 59);
+    case 59: return new SketchImpl<Field59>(implementation, 59, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_60
-    case 60: return new SketchImpl<Field60>(implementation, 60);
+    case 60: return new SketchImpl<Field60>(implementation, 60, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_61
-    case 61: return new SketchImpl<Field61>(implementation, 61);
+    case 61: return new SketchImpl<Field61>(implementation, 61, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_62
-    case 62: return new SketchImpl<Field62>(implementation, 62);
+    case 62: return new SketchImpl<Field62>(implementation, 62, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_63
-    case 63: return new SketchImpl<Field63>(implementation, 63);
+    case 63: return new SketchImpl<Field63>(implementation, 63, seed);
 #endif
 #ifdef ENABLE_FIELD_INT_64
-    case 64: return new SketchImpl<Field64>(implementation, 64);
+    case 64: return new SketchImpl<Field64>(implementation, 64, seed);
 #endif
     default: return nullptr;
     }

--- a/src/minisketch.cpp
+++ b/src/minisketch.cpp
@@ -25,32 +25,32 @@
 #  endif
 #endif
 
-Sketch* ConstructGeneric1Byte(int bits, int implementation);
-Sketch* ConstructGeneric2Bytes(int bits, int implementation);
-Sketch* ConstructGeneric3Bytes(int bits, int implementation);
-Sketch* ConstructGeneric4Bytes(int bits, int implementation);
-Sketch* ConstructGeneric5Bytes(int bits, int implementation);
-Sketch* ConstructGeneric6Bytes(int bits, int implementation);
-Sketch* ConstructGeneric7Bytes(int bits, int implementation);
-Sketch* ConstructGeneric8Bytes(int bits, int implementation);
+Sketch* ConstructGeneric1Byte(int bits, int implementation, uint64_t seed);
+Sketch* ConstructGeneric2Bytes(int bits, int implementation, uint64_t seed);
+Sketch* ConstructGeneric3Bytes(int bits, int implementation, uint64_t seed);
+Sketch* ConstructGeneric4Bytes(int bits, int implementation, uint64_t seed);
+Sketch* ConstructGeneric5Bytes(int bits, int implementation, uint64_t seed);
+Sketch* ConstructGeneric6Bytes(int bits, int implementation, uint64_t seed);
+Sketch* ConstructGeneric7Bytes(int bits, int implementation, uint64_t seed);
+Sketch* ConstructGeneric8Bytes(int bits, int implementation, uint64_t seed);
 
 #ifdef HAVE_CLMUL
-Sketch* ConstructClMul1Byte(int bits, int implementation);
-Sketch* ConstructClMul2Bytes(int bits, int implementation);
-Sketch* ConstructClMul3Bytes(int bits, int implementation);
-Sketch* ConstructClMul4Bytes(int bits, int implementation);
-Sketch* ConstructClMul5Bytes(int bits, int implementation);
-Sketch* ConstructClMul6Bytes(int bits, int implementation);
-Sketch* ConstructClMul7Bytes(int bits, int implementation);
-Sketch* ConstructClMul8Bytes(int bits, int implementation);
-Sketch* ConstructClMulTri1Byte(int bits, int implementation);
-Sketch* ConstructClMulTri2Bytes(int bits, int implementation);
-Sketch* ConstructClMulTri3Bytes(int bits, int implementation);
-Sketch* ConstructClMulTri4Bytes(int bits, int implementation);
-Sketch* ConstructClMulTri5Bytes(int bits, int implementation);
-Sketch* ConstructClMulTri6Bytes(int bits, int implementation);
-Sketch* ConstructClMulTri7Bytes(int bits, int implementation);
-Sketch* ConstructClMulTri8Bytes(int bits, int implementation);
+Sketch* ConstructClMul1Byte(int bits, int implementation, uint64_t seed);
+Sketch* ConstructClMul2Bytes(int bits, int implementation, uint64_t seed);
+Sketch* ConstructClMul3Bytes(int bits, int implementation, uint64_t seed);
+Sketch* ConstructClMul4Bytes(int bits, int implementation, uint64_t seed);
+Sketch* ConstructClMul5Bytes(int bits, int implementation, uint64_t seed);
+Sketch* ConstructClMul6Bytes(int bits, int implementation, uint64_t seed);
+Sketch* ConstructClMul7Bytes(int bits, int implementation, uint64_t seed);
+Sketch* ConstructClMul8Bytes(int bits, int implementation, uint64_t seed);
+Sketch* ConstructClMulTri1Byte(int bits, int implementation, uint64_t seed);
+Sketch* ConstructClMulTri2Bytes(int bits, int implementation, uint64_t seed);
+Sketch* ConstructClMulTri3Bytes(int bits, int implementation, uint64_t seed);
+Sketch* ConstructClMulTri4Bytes(int bits, int implementation, uint64_t seed);
+Sketch* ConstructClMulTri5Bytes(int bits, int implementation, uint64_t seed);
+Sketch* ConstructClMulTri6Bytes(int bits, int implementation, uint64_t seed);
+Sketch* ConstructClMulTri7Bytes(int bits, int implementation, uint64_t seed);
+Sketch* ConstructClMulTri8Bytes(int bits, int implementation, uint64_t seed);
 #endif
 
 namespace {
@@ -77,27 +77,27 @@ static inline bool EnableClmul()
 }
 #endif
 
-Sketch* Construct(int bits, int impl)
+Sketch* Construct(int bits, int impl, uint64_t seed)
 {
     switch (FieldImpl(impl)) {
     case FieldImpl::GENERIC:
         switch ((bits + 7) / 8) {
         case 1:
-            return ConstructGeneric1Byte(bits, impl);
+            return ConstructGeneric1Byte(bits, impl, seed);
         case 2:
-            return ConstructGeneric2Bytes(bits, impl);
+            return ConstructGeneric2Bytes(bits, impl, seed);
         case 3:
-            return ConstructGeneric3Bytes(bits, impl);
+            return ConstructGeneric3Bytes(bits, impl, seed);
         case 4:
-            return ConstructGeneric4Bytes(bits, impl);
+            return ConstructGeneric4Bytes(bits, impl, seed);
         case 5:
-            return ConstructGeneric5Bytes(bits, impl);
+            return ConstructGeneric5Bytes(bits, impl, seed);
         case 6:
-            return ConstructGeneric6Bytes(bits, impl);
+            return ConstructGeneric6Bytes(bits, impl, seed);
         case 7:
-            return ConstructGeneric7Bytes(bits, impl);
+            return ConstructGeneric7Bytes(bits, impl, seed);
         case 8:
-            return ConstructGeneric8Bytes(bits, impl);
+            return ConstructGeneric8Bytes(bits, impl, seed);
         default:
             return nullptr;
         }
@@ -107,21 +107,21 @@ Sketch* Construct(int bits, int impl)
         if (EnableClmul()) {
             switch ((bits + 7) / 8) {
             case 1:
-                return ConstructClMul1Byte(bits, impl);
+                return ConstructClMul1Byte(bits, impl, seed);
             case 2:
-                return ConstructClMul2Bytes(bits, impl);
+                return ConstructClMul2Bytes(bits, impl, seed);
             case 3:
-                return ConstructClMul3Bytes(bits, impl);
+                return ConstructClMul3Bytes(bits, impl, seed);
             case 4:
-                return ConstructClMul4Bytes(bits, impl);
+                return ConstructClMul4Bytes(bits, impl, seed);
             case 5:
-                return ConstructClMul5Bytes(bits, impl);
+                return ConstructClMul5Bytes(bits, impl, seed);
             case 6:
-                return ConstructClMul6Bytes(bits, impl);
+                return ConstructClMul6Bytes(bits, impl, seed);
             case 7:
-                return ConstructClMul7Bytes(bits, impl);
+                return ConstructClMul7Bytes(bits, impl, seed);
             case 8:
-                return ConstructClMul8Bytes(bits, impl);
+                return ConstructClMul8Bytes(bits, impl, seed);
             default:
                 return nullptr;
             }
@@ -131,21 +131,21 @@ Sketch* Construct(int bits, int impl)
         if (EnableClmul()) {
             switch ((bits + 7) / 8) {
             case 1:
-                return ConstructClMulTri1Byte(bits, impl);
+                return ConstructClMulTri1Byte(bits, impl, seed);
             case 2:
-                return ConstructClMulTri2Bytes(bits, impl);
+                return ConstructClMulTri2Bytes(bits, impl, seed);
             case 3:
-                return ConstructClMulTri3Bytes(bits, impl);
+                return ConstructClMulTri3Bytes(bits, impl, seed);
             case 4:
-                return ConstructClMulTri4Bytes(bits, impl);
+                return ConstructClMulTri4Bytes(bits, impl, seed);
             case 5:
-                return ConstructClMulTri5Bytes(bits, impl);
+                return ConstructClMulTri5Bytes(bits, impl, seed);
             case 6:
-                return ConstructClMulTri6Bytes(bits, impl);
+                return ConstructClMulTri6Bytes(bits, impl, seed);
             case 7:
-                return ConstructClMulTri7Bytes(bits, impl);
+                return ConstructClMulTri7Bytes(bits, impl, seed);
             case 8:
-                return ConstructClMulTri8Bytes(bits, impl);
+                return ConstructClMulTri8Bytes(bits, impl, seed);
             default:
                 return nullptr;
             }
@@ -366,7 +366,7 @@ int minisketch_implementation_supported(uint32_t bits, uint32_t implementation) 
         return 0;
     }
     try {
-        Sketch* sketch = Construct(bits, implementation);
+        Sketch* sketch = Construct(bits, implementation, 0);
         if (sketch) {
             delete sketch;
             return 1;
@@ -375,9 +375,9 @@ int minisketch_implementation_supported(uint32_t bits, uint32_t implementation) 
     return 0;
 }
 
-minisketch* minisketch_create(uint32_t bits, uint32_t implementation, size_t capacity) {
+minisketch* minisketch_create(uint32_t bits, uint32_t implementation, size_t capacity, uint64_t seed) {
     try {
-        Sketch* sketch = Construct(bits, implementation);
+        Sketch* sketch = Construct(bits, implementation, seed);
         if (sketch) {
             try {
                 sketch->Init(capacity);
@@ -414,9 +414,9 @@ uint32_t minisketch_implementation(const minisketch* sketch) {
 minisketch* minisketch_clone(const minisketch* sketch) {
     const Sketch* s = (const Sketch*)sketch;
     s->Check();
-    Sketch* r = (Sketch*) minisketch_create(s->Bits(), s->Implementation(), s->Syndromes());
+    Sketch* r = s->Clone();
     if (r) {
-        r->Merge(s);
+        r->Check();
     }
     return (minisketch*) r;
 }

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -35,6 +35,7 @@ public:
     virtual void Deserialize(const unsigned char*) = 0;
     virtual size_t Merge(const Sketch* other_sketch) = 0;
     virtual void SetSeed(uint64_t seed) = 0;
+    virtual Sketch* Clone() const = 0;
 
     virtual int Decode(int max_count, uint64_t* roots) const = 0;
 };

--- a/src/sketch_impl.h
+++ b/src/sketch_impl.h
@@ -360,11 +360,11 @@ class SketchImpl final : public Sketch
 
 public:
     template<typename... Args>
-    SketchImpl(int implementation, int bits, const Args&... args) : Sketch(implementation, bits), m_field(args...) {
-        std::random_device rng;
-        std::uniform_int_distribution<uint64_t> dist;
-        m_basis = m_field.FromSeed(dist(rng));
+    SketchImpl(int implementation, int bits, uint64_t seed, const Args&... args) : Sketch(implementation, bits), m_field(args...) {
+        m_basis = m_field.FromSeed(seed);
     }
+
+    SketchImpl(const SketchImpl& other) = default;
 
     size_t Syndromes() const override { return m_syndromes.size(); }
     void Init(size_t count) override { m_syndromes.assign(count, 0); }
@@ -428,6 +428,11 @@ public:
         } else {
             m_basis = m_field.FromSeed(seed);
         }
+    }
+
+    Sketch* Clone() const override
+    {
+        return new SketchImpl<F>(*this);
     }
 };
 

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -28,13 +28,13 @@ uint64_t Combination(uint64_t n, uint64_t k) {
 }
 
 /** Create a vector with Minisketch objects, one for each implementation. */
-std::vector<Minisketch> CreateSketches(uint32_t bits, size_t capacity) {
+std::vector<Minisketch> CreateSketches(uint32_t bits, size_t capacity, uint64_t seed) {
     if (!Minisketch::BitsSupported(bits)) return {};
     std::vector<Minisketch> ret;
     for (uint32_t impl = 0; impl <= Minisketch::MaxImplementation(); ++impl) {
         if (Minisketch::ImplementationSupported(bits, impl)) {
             CHECK(Minisketch::BitsSupported(bits));
-            ret.push_back(Minisketch(bits, impl, capacity));
+            ret.push_back(Minisketch(bits, impl, capacity, seed));
             CHECK((bool)ret.back());
         } else {
             // implementation 0 must always work unless field size is disabled
@@ -46,10 +46,10 @@ std::vector<Minisketch> CreateSketches(uint32_t bits, size_t capacity) {
 
 /** Test properties by exhaustively decoding all 2**(bits*capacity) sketches
  *  with specified capacity and bits. */
-void TestExhaustive(uint32_t bits, size_t capacity) {
-    auto sketches = CreateSketches(bits, capacity);
+void TestExhaustive(uint32_t bits, size_t capacity, uint64_t seed) {
+    auto sketches = CreateSketches(bits, capacity, seed);
     if (sketches.empty()) return;
-    auto sketches_rebuild = CreateSketches(bits, capacity);
+    auto sketches_rebuild = CreateSketches(bits, capacity, seed + 1);
 
     std::vector<unsigned char> serialized;
     std::vector<unsigned char> serialized_empty;
@@ -125,6 +125,7 @@ void TestExhaustive(uint32_t bits, size_t capacity) {
 /** Test properties of sketches with random elements put in. */
 void TestRandomized(uint32_t bits, size_t max_capacity, size_t iter) {
     std::random_device rnd;
+    std::uniform_int_distribution<uint64_t> seed_dist;
     std::uniform_int_distribution<uint64_t> capacity_dist(0, std::min<uint64_t>(std::numeric_limits<uint64_t>::max() >> (64 - bits), max_capacity));
     std::uniform_int_distribution<uint64_t> element_dist(1, std::numeric_limits<uint64_t>::max() >> (64 - bits));
     std::uniform_int_distribution<uint64_t> rand64(0, std::numeric_limits<uint64_t>::max());
@@ -138,7 +139,7 @@ void TestRandomized(uint32_t bits, size_t max_capacity, size_t iter) {
     for (size_t i = 0; i < iter; ++i) {
         // Determine capacity, and construct Minisketch objects for all implementations.
         uint64_t capacity = capacity_dist(rnd);
-        auto sketches = CreateSketches(bits, capacity);
+        auto sketches = CreateSketches(bits, capacity, seed_dist(rnd));
         // Sanity checks
         if (sketches.empty()) return;
         for (size_t impl = 0; impl < sketches.size(); ++impl) {
@@ -268,6 +269,8 @@ void TestComputeFunctions() {
 } // namespace
 
 int main(int argc, char** argv) {
+    std::random_device rnd;
+    std::uniform_int_distribution<uint64_t> seed_dist;
     uint64_t test_complexity = 4;
     if (argc > 1) {
         size_t len = 0;
@@ -307,7 +310,7 @@ int main(int argc, char** argv) {
         for (int bits = 2; weight == 0 ? bits <= 64 : (bits <= 32 && bits <= weight); ++bits) {
             int capacity = weight / bits;
             if (capacity * bits != weight) continue;
-            TestExhaustive(bits, capacity);
+            TestExhaustive(bits, capacity, seed_dist(rnd));
         }
         if (weight >= 16 && test_complexity >> (weight - 16) == 0) break;
     }


### PR DESCRIPTION
Instead of relying on the C++ `std::random_device` and `std::uniform_int_distribution` (which lack strong quality guarantees), move the responsibility for generating good randomness to the user.

All constructors and functions related to sketch construction are modified to take in an explicit `uint64_t seed` value. The test code still uses the C++ randomness functions.

Fixes #93.