### PR TITLE
Fix UB in benchmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,18 +28,12 @@ jobs:
             build_configuration: 'Release'
           - job_name: 'x64 (MSVC): Windows (VS 2022, debug)'
             build_configuration: 'Debug'
-            # TODO: Resolve the issue and re-enable benchmark.
-            # See: https://github.com/bitcoin-core/minisketch/pull/96.
-            skip_benchmark: true
           - job_name: 'x64 (MSVC): Windows (VS 2022, shared)'
             cmake_options: '-DBUILD_SHARED_LIBS=ON'
             build_configuration: 'Release'
           - job_name: 'x64 (clang-cl): Windows (VS 2022)'
             cmake_options: '-T ClangCL'
             build_configuration: 'Release'
-            # TODO: Resolve the issue and re-enable benchmark.
-            # See: https://github.com/bitcoin-core/minisketch/pull/96.
-            skip_benchmark: true
 
     steps:
       - name: Checkout
@@ -64,6 +58,5 @@ jobs:
         run: ctest --output-on-failure -j $env:NUMBER_OF_PROCESSORS -C ${{ matrix.configuration.build_configuration }}
 
       - name: Benchmark
-        if: ${{ ! matrix.configuration.skip_benchmark }}
         working-directory: build
         run: bin\${{ matrix.configuration.build_configuration }}\bench.exe

--- a/src/bench.cpp
+++ b/src/bench.cpp
@@ -6,6 +6,7 @@
 
 #include "../include/minisketch.h"
 #include <string.h>
+#include <limits>
 #include <memory>
 #include <vector>
 #include <chrono>
@@ -42,7 +43,8 @@ int main(int argc, char** argv) {
             std::vector<minisketch*> states;
             std::vector<uint64_t> roots(2 * syndromes);
             std::random_device rng;
-            std::uniform_int_distribution<uint64_t> dist(1, (uint64_t(1) << bits) - 1);
+            auto upper_bound = std::numeric_limits<uint64_t>::max() >> (64 - bits);
+            std::uniform_int_distribution<uint64_t> dist(1, upper_bound);
             states.resize(iters);
             std::vector<double> benches;
             benches.reserve(iters);


### PR DESCRIPTION
From https://en.cppreference.com/w/c/language/operator_arithmetic.html:
> The behavior is undefined if _`rhs`_ is negative or is greater or equal the number of bits in the promoted _`lhs`_.

Steps to reproduce on Ubuntu 25.04 using the master branch @ ea8f66b1eabb0388d221daaa4706120a5083da0c:
```
$ ./autogen.sh
$ ./configure --enable-benchmark CXX=clang++-20 CXXFLAGS="-O0"
$ make bench -j $(nproc) bench
$ ./bench
<snip>
recover[ms]	 63	 260.72278	         -	  62.21269	
create[ns]	 63	  79.66483	         -	  17.74962	
/usr/lib/gcc/x86_64-linux-gnu/15/../../../../include/c++/15/bits/uniform_int_dist.h:108: std::uniform_int_distribution<unsigned long>::param_type::param_type(_IntType, _IntType) [_IntType = unsigned long]: Assertion '_M_a <= _M_b' failed.
Aborted (core dumped)
```