### PR TITLE
Allow Git to track changes in the `.github` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 *.dll
 *.dylib
 *.so.*
-.*
 *.a
 *~
 
@@ -30,6 +29,9 @@ config.status
 configure
 libtool
 stamp-h1
+/.libs/
+.deps/
+.dirstamp
 
 test*
 bench


### PR DESCRIPTION
On the master branch, pattern `.*` is too broad and prevents the `.github` directory added in 850cc868d54f13728c85f1c3b137f372ef4f4051 from being tracking.

This PR updates the `.gitignore` file accordingly.