### PR TITLE
Add ARM PMULL support

### DIFF
--- a/cmake/SystemIntrospection.cmake
+++ b/cmake/SystemIntrospection.cmake
@@ -4,7 +4,7 @@ include(CheckCXXSourceCompiles)
 include(CMakePushCheckState)
 cmake_push_check_state(RESET)
 
-# Check for clmul instructions support.
+# Check for carryless-multiply support: first x86 CLMUL, then ARMv8 PMULL.
 if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   set(CMAKE_REQUIRED_FLAGS "-mpclmul")
 endif()
@@ -21,10 +21,37 @@ check_cxx_source_compiles("
     uint64_t e = _mm_cvtsi128_si64(d);
     return e == 0;
   }
-  " HAVE_CLMUL
+  " HAVE_CLMUL_X86
 )
-if(HAVE_CLMUL)
+if(HAVE_CLMUL_X86)
   set(CLMUL_CXXFLAGS ${CMAKE_REQUIRED_FLAGS})
+  set(HAVE_CLMUL TRUE)
+endif()
+
+# Try aarch64 PMULL.
+if(NOT HAVE_CLMUL AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  set(CMAKE_REQUIRED_FLAGS "-march=armv8-a+crypto")
+  check_cxx_source_compiles("
+    #include <arm_neon.h>
+    #include <stdint.h>
+
+    int main()
+    {
+      uint64x2_t a = vcombine_u64(vcreate_u64((uint64_t)7), vdup_n_u64(0));
+      poly64_t al = (poly64_t)vgetq_lane_u64(a, 0);
+      poly128_t p = vmull_p64(al, al);
+      uint64x2_t b = vreinterpretq_u64_p128(p);
+      uint64x2_t c = vshrq_n_u64(b, 41);
+      uint64x2_t d = veorq_u64(b, c);
+      uint64_t e = vgetq_lane_u64(d, 0);
+      return e == 0;
+    }
+    " HAVE_PMULL_AARCH64
+  )
+  if(HAVE_PMULL_AARCH64)
+    set(CLMUL_CXXFLAGS ${CMAKE_REQUIRED_FLAGS})
+    set(HAVE_CLMUL TRUE)
+  endif()
 endif()
 
 if(CMAKE_CXX_STANDARD LESS 20)

--- a/configure.ac
+++ b/configure.ac
@@ -57,6 +57,7 @@ AX_CHECK_COMPILE_FLAG([-Werror],[CXXFLAG_WERROR="-Werror"],[CXXFLAG_WERROR=""])
 
 AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory])
 enable_clmul=
+enable_pmull=
 AX_CHECK_COMPILE_FLAG([-mpclmul],[[enable_clmul=yes]],,[[$CXXFLAG_WERROR]],[AC_LANG_PROGRAM([
   #include <stdint.h>
   #include <x86intrin.h>
@@ -70,7 +71,26 @@ AX_CHECK_COMPILE_FLAG([-mpclmul],[[enable_clmul=yes]],,[[$CXXFLAG_WERROR]],[AC_L
 ])])
 if test x$enable_clmul = xyes; then
   CLMUL_CXXFLAGS="-mpclmul"
-  AC_DEFINE(HAVE_CLMUL, 1, [Define this symbol if clmul instructions can be used])
+  AC_DEFINE(HAVE_CLMUL, 1, [Define this symbol if clmul (x86) or pmull (ARM) instructions can be used])
+else
+  dnl Fall back to ARMv8 crypto (PMULL/PMULL2). aarch64 uses -march=armv8-a+crypto;
+  AX_CHECK_COMPILE_FLAG([-march=armv8-a+crypto],[[enable_pmull=yes]],,[[$CXXFLAG_WERROR]],[AC_LANG_PROGRAM([
+    #include <stdint.h>
+    #include <arm_neon.h>
+  ], [
+    uint64x2_t a = vcombine_u64(vcreate_u64((uint64_t)7), vdup_n_u64(0));
+    poly64_t al = (poly64_t)vgetq_lane_u64(a, 0);
+    poly128_t p = vmull_p64(al, al);
+    uint64x2_t b = vreinterpretq_u64_p128(p);
+    uint64x2_t c = vshrq_n_u64(b, 41);
+    uint64x2_t d = veorq_u64(b, c);
+    uint64_t e = vgetq_lane_u64(d, 0);
+    return e == 0;
+  ])])
+  if test x$enable_pmull = xyes; then
+    CLMUL_CXXFLAGS="-march=armv8-a+crypto"
+    AC_DEFINE(HAVE_CLMUL, 1, [Define this symbol if clmul (x86) or pmull (ARM) instructions can be used])
+  fi
 fi
 
 
@@ -133,7 +153,7 @@ AC_SUBST(NOWARN_CXXFLAGS)
 AC_SUBST(VERIFY_DEFINES)
 AC_SUBST(RELEASE_DEFINES)
 AC_SUBST(LIBTOOL_APP_LDFLAGS)
-AM_CONDITIONAL([ENABLE_CLMUL],[test x$enable_clmul = xyes])
+AM_CONDITIONAL([ENABLE_CLMUL],[test x$enable_clmul = xyes -o x$enable_pmull = xyes])
 AM_CONDITIONAL([USE_BENCHMARK], [test x"$use_benchmark" = x"yes"])
 AM_CONDITIONAL([USE_TESTS], [test x"$use_tests" != x"no"])
 AC_OUTPUT
@@ -143,6 +163,7 @@ echo "Build Options:"
 echo "  with benchmarks         = $use_benchmark"
 echo "  with tests              = $use_tests"
 echo "  enable clmul fields     = $enable_clmul"
+echo "  enable pmull fields     = $enable_pmull"
 echo "  CXX                     = $CXX"
 echo "  CXXFLAGS                = $CXXFLAGS"
 echo "  CPPFLAGS                = $CPPFLAGS"

--- a/src/fields/clmul_common_impl.h
+++ b/src/fields/clmul_common_impl.h
@@ -8,7 +8,16 @@
 #define _MINISKETCH_FIELDS_CLMUL_COMMON_IMPL_H_ 1
 
 #include <stdint.h>
-#include <immintrin.h>
+
+#if defined(__PCLMUL__)
+#  include <immintrin.h>
+#  define MINISKETCH_CLMUL_X86 1
+#elif defined(__ARM_FEATURE_CRYPTO) || defined(__ARM_FEATURE_AES)
+#  include <arm_neon.h>
+#  define MINISKETCH_CLMUL_ARM 1
+#else
+#  error "clmul_common_impl.h included without a carryless-multiply ISA enabled"
+#endif
 
 #include "../int_utils.h"
 #include "../lintrans.h"
@@ -34,10 +43,12 @@ namespace {
 //
 // Two type aliases are exposed:
 //   Clmul128  — 128-bit in-flight data (inputs to XOR, OR, and the lane shifts).
-//   ClmulPoly — the type a PMULL/PCLMULQDQ operand wants. On x86 this coincides
-//               with Clmul128; a future ARM backend would alias it to poly64x2_t
-//               so vmull_p64 reads naturally. ClmulAsPoly is the zero-cost
-//               conversion.
+//   ClmulPoly — the type a PMULL/PCLMULQDQ operand wants. On x86 the two aliases
+//               coincide; on ARM ClmulPoly is poly64x2_t so vmull_p64 reads
+//               naturally without polluting the lane-shift code with poly casts.
+//               ClmulAsPoly is the zero-cost conversion from the in-flight type
+//               to the operand type.
+#if defined(MINISKETCH_CLMUL_X86)
 using Clmul128 = __m128i;
 using ClmulPoly = __m128i;
 
@@ -53,6 +64,39 @@ static inline Clmul128 ClmulOr(Clmul128 a, Clmul128 b) { return _mm_or_si128(a, 
 template<int N> static inline Clmul128 ClmulSrliEpi64(Clmul128 v) { return _mm_srli_epi64(v, N); }
 template<int N> static inline Clmul128 ClmulSlliEpi64(Clmul128 v) { return _mm_slli_epi64(v, N); }
 template<int N> static inline Clmul128 ClmulSrliBytes(Clmul128 v) { return _mm_srli_si128(v, N); }
+#elif defined(MINISKETCH_CLMUL_ARM)
+// In-flight data is uint64x2_t — directly consumed by vshrq_n_u64, vshlq_n_u64,
+// veorq_u64, vorrq_u64. PMULL operands are poly64x2_t, the type vmull_p64's scalar
+// arguments are extracted from via vgetq_lane_p64. ClmulAsPoly is a zero-cost
+// reinterpret. With GCC 13+/Clang 19+ at -O2+, vgetq_lane_p64 + vmull_p64 fuse
+// into a direct PMULL with NEON operands — values don't spill to GPRs.
+using Clmul128 = uint64x2_t;
+using ClmulPoly = poly64x2_t;
+
+static inline ClmulPoly ClmulAsPoly(Clmul128 v) { return vreinterpretq_p64_u64(v); }
+// Load a scalar into lane 0, lane 1 zeroed — mirrors _mm_cvtsi64_si128's
+// "payload in the low 64 bits" semantics.
+static inline ClmulPoly ClmulLoad64(uint64_t x) {
+    return vsetq_lane_p64((poly64_t)x, vdupq_n_p64(0), 0);
+}
+static inline uint64_t ClmulExtract64(Clmul128 v) { return vgetq_lane_u64(v, 0); }
+// lo(a) × lo(b) via PMULL.
+static inline Clmul128 Clmul00(ClmulPoly a, ClmulPoly b) {
+    return vreinterpretq_u64_p128(vmull_p64(vgetq_lane_p64(a, 0), vgetq_lane_p64(b, 0)));
+}
+// hi(a) × lo(b) via PMULL — mirrors _mm_clmulepi64_si128(a, b, 0x01), which selects
+// the high quadword of a (imm8 bit 0 set) and the low quadword of b (imm8 bit 4 clear).
+static inline Clmul128 Clmul01(ClmulPoly a, ClmulPoly b) {
+    return vreinterpretq_u64_p128(vmull_p64(vgetq_lane_p64(a, 1), vgetq_lane_p64(b, 0)));
+}
+static inline Clmul128 ClmulXor(Clmul128 a, Clmul128 b) { return veorq_u64(a, b); }
+static inline Clmul128 ClmulOr(Clmul128 a, Clmul128 b) { return vorrq_u64(a, b); }
+template<int N> static inline Clmul128 ClmulSrliEpi64(Clmul128 v) { return vshrq_n_u64(v, N); }
+template<int N> static inline Clmul128 ClmulSlliEpi64(Clmul128 v) { return vshlq_n_u64(v, N); }
+template<int N> static inline Clmul128 ClmulSrliBytes(Clmul128 v) {
+    return vreinterpretq_u64_u8(vextq_u8(vreinterpretq_u8_u64(v), vdupq_n_u8(0), N));
+}
+#endif
 
 template<typename I, int BITS, I MOD> NO_SANITIZE_MEMORY I MulWithClMulReduce(I a, I b)
 {

--- a/src/fields/clmul_common_impl.h
+++ b/src/fields/clmul_common_impl.h
@@ -28,39 +28,65 @@ namespace {
 #  define NO_SANITIZE_MEMORY
 #endif
 
+// Thin portability layer over the carryless-multiply primitive. MulWithClMulReduce
+// and MulTrinomial below are written against this API; adding a new ISA amounts to
+// supplying a new body for each wrapper.
+//
+// Two type aliases are exposed:
+//   Clmul128  — 128-bit in-flight data (inputs to XOR, OR, and the lane shifts).
+//   ClmulPoly — the type a PMULL/PCLMULQDQ operand wants. On x86 this coincides
+//               with Clmul128; a future ARM backend would alias it to poly64x2_t
+//               so vmull_p64 reads naturally. ClmulAsPoly is the zero-cost
+//               conversion.
+using Clmul128 = __m128i;
+using ClmulPoly = __m128i;
+
+static inline ClmulPoly ClmulAsPoly(Clmul128 v) { return v; }
+static inline ClmulPoly ClmulLoad64(uint64_t x) { return _mm_cvtsi64_si128(x); }
+static inline uint64_t ClmulExtract64(Clmul128 v) { return _mm_cvtsi128_si64(v); }
+// lo(a) × lo(b).
+static inline Clmul128 Clmul00(ClmulPoly a, ClmulPoly b) { return _mm_clmulepi64_si128(a, b, 0x00); }
+// hi(a) × lo(b). (imm8 bit 0 selects the high half of a; bit 4 clear selects the low half of b.)
+static inline Clmul128 Clmul01(ClmulPoly a, ClmulPoly b) { return _mm_clmulepi64_si128(a, b, 0x01); }
+static inline Clmul128 ClmulXor(Clmul128 a, Clmul128 b) { return _mm_xor_si128(a, b); }
+static inline Clmul128 ClmulOr(Clmul128 a, Clmul128 b) { return _mm_or_si128(a, b); }
+template<int N> static inline Clmul128 ClmulSrliEpi64(Clmul128 v) { return _mm_srli_epi64(v, N); }
+template<int N> static inline Clmul128 ClmulSlliEpi64(Clmul128 v) { return _mm_slli_epi64(v, N); }
+template<int N> static inline Clmul128 ClmulSrliBytes(Clmul128 v) { return _mm_srli_si128(v, N); }
+
 template<typename I, int BITS, I MOD> NO_SANITIZE_MEMORY I MulWithClMulReduce(I a, I b)
 {
     static constexpr I MASK = Mask<BITS, I>();
 
-    const __m128i MOD128 = _mm_cvtsi64_si128(MOD);
-    __m128i product = _mm_clmulepi64_si128(_mm_cvtsi64_si128((uint64_t)a), _mm_cvtsi64_si128((uint64_t)b), 0x00);
+    const ClmulPoly MOD128 = ClmulLoad64(MOD);
+    Clmul128 product = Clmul00(ClmulLoad64((uint64_t)a), ClmulLoad64((uint64_t)b));
     if (BITS <= 32) {
-        __m128i high1 = _mm_srli_epi64(product, BITS);
-        __m128i red1 = _mm_clmulepi64_si128(high1, MOD128, 0x00);
-        __m128i high2 = _mm_srli_epi64(red1, BITS);
-        __m128i red2 = _mm_clmulepi64_si128(high2, MOD128, 0x00);
-        return _mm_cvtsi128_si64(_mm_xor_si128(_mm_xor_si128(product, red1), red2)) & MASK;
+        Clmul128 high1 = ClmulSrliEpi64<BITS>(product);
+        Clmul128 red1 = Clmul00(ClmulAsPoly(high1), MOD128);
+        Clmul128 high2 = ClmulSrliEpi64<BITS>(red1);
+        Clmul128 red2 = Clmul00(ClmulAsPoly(high2), MOD128);
+        return ClmulExtract64(ClmulXor(ClmulXor(product, red1), red2)) & MASK;
     } else if (BITS == 64) {
-        __m128i red1 = _mm_clmulepi64_si128(product, MOD128, 0x01);
-        __m128i red2 = _mm_clmulepi64_si128(red1, MOD128, 0x01);
-        return _mm_cvtsi128_si64(_mm_xor_si128(_mm_xor_si128(product, red1), red2));
+        Clmul128 red1 = Clmul01(ClmulAsPoly(product), MOD128);
+        Clmul128 red2 = Clmul01(ClmulAsPoly(red1), MOD128);
+        return ClmulExtract64(ClmulXor(ClmulXor(product, red1), red2));
     } else if ((BITS % 8) == 0) {
-        __m128i high1 = _mm_srli_si128(product, BITS / 8);
-        __m128i red1 = _mm_clmulepi64_si128(high1, MOD128, 0x00);
-        __m128i high2 = _mm_srli_si128(red1, BITS / 8);
-        __m128i red2 = _mm_clmulepi64_si128(high2, MOD128, 0x00);
-        return _mm_cvtsi128_si64(_mm_xor_si128(_mm_xor_si128(product, red1), red2)) & MASK;
+        Clmul128 high1 = ClmulSrliBytes<BITS / 8>(product);
+        Clmul128 red1 = Clmul00(ClmulAsPoly(high1), MOD128);
+        Clmul128 high2 = ClmulSrliBytes<BITS / 8>(red1);
+        Clmul128 red2 = Clmul00(ClmulAsPoly(high2), MOD128);
+        return ClmulExtract64(ClmulXor(ClmulXor(product, red1), red2)) & MASK;
     } else {
-        __m128i high1 = _mm_or_si128(_mm_srli_epi64(product, BITS), _mm_srli_si128(_mm_slli_epi64(product, 64 - BITS), 8));
-        __m128i red1 = _mm_clmulepi64_si128(high1, MOD128, 0x00);
+        Clmul128 high1 = ClmulOr(ClmulSrliEpi64<BITS>(product), ClmulSrliBytes<8>(ClmulSlliEpi64<64 - BITS>(product)));
+        Clmul128 red1 = Clmul00(ClmulAsPoly(high1), MOD128);
         if ((uint64_t(MOD) >> (66 - BITS)) == 0) {
-            __m128i high2 = _mm_srli_epi64(red1, BITS);
-            __m128i red2 = _mm_clmulepi64_si128(high2, MOD128, 0x00);
-            return _mm_cvtsi128_si64(_mm_xor_si128(_mm_xor_si128(product, red1), red2)) & MASK;
+            Clmul128 high2 = ClmulSrliEpi64<BITS>(red1);
+            Clmul128 red2 = Clmul00(ClmulAsPoly(high2), MOD128);
+            return ClmulExtract64(ClmulXor(ClmulXor(product, red1), red2)) & MASK;
         } else {
-            __m128i high2 = _mm_or_si128(_mm_srli_epi64(red1, BITS), _mm_srli_si128(_mm_slli_epi64(red1, 64 - BITS), 8));
-            __m128i red2 = _mm_clmulepi64_si128(high2, MOD128, 0x00);
-            return _mm_cvtsi128_si64(_mm_xor_si128(_mm_xor_si128(product, red1), red2)) & MASK;
+            Clmul128 high2 = ClmulOr(ClmulSrliEpi64<BITS>(red1), ClmulSrliBytes<8>(ClmulSlliEpi64<64 - BITS>(red1)));
+            Clmul128 red2 = Clmul00(ClmulAsPoly(high2), MOD128);
+            return ClmulExtract64(ClmulXor(ClmulXor(product, red1), red2)) & MASK;
         }
     }
 }
@@ -69,34 +95,34 @@ template<typename I, int BITS, int POS> NO_SANITIZE_MEMORY I MulTrinomial(I a, I
 {
     static constexpr I MASK = Mask<BITS, I>();
 
-    __m128i product = _mm_clmulepi64_si128(_mm_cvtsi64_si128((uint64_t)a), _mm_cvtsi64_si128((uint64_t)b), 0x00);
+    Clmul128 product = Clmul00(ClmulLoad64((uint64_t)a), ClmulLoad64((uint64_t)b));
     if (BITS <= 32) {
-        __m128i high1 = _mm_srli_epi64(product, BITS);
-        __m128i red1 = _mm_xor_si128(high1, _mm_slli_epi64(high1, POS));
+        Clmul128 high1 = ClmulSrliEpi64<BITS>(product);
+        Clmul128 red1 = ClmulXor(high1, ClmulSlliEpi64<POS>(high1));
         if (POS == 1) {
-            return _mm_cvtsi128_si64(_mm_xor_si128(product, red1)) & MASK;
+            return ClmulExtract64(ClmulXor(product, red1)) & MASK;
         } else {
-            __m128i high2 = _mm_srli_epi64(red1, BITS);
-            __m128i red2 = _mm_xor_si128(high2, _mm_slli_epi64(high2, POS));
-            return _mm_cvtsi128_si64(_mm_xor_si128(_mm_xor_si128(product, red1), red2)) & MASK;
+            Clmul128 high2 = ClmulSrliEpi64<BITS>(red1);
+            Clmul128 red2 = ClmulXor(high2, ClmulSlliEpi64<POS>(high2));
+            return ClmulExtract64(ClmulXor(ClmulXor(product, red1), red2)) & MASK;
         }
     } else {
-        __m128i high1 = _mm_or_si128(_mm_srli_epi64(product, BITS), _mm_srli_si128(_mm_slli_epi64(product, 64 - BITS), 8));
+        Clmul128 high1 = ClmulOr(ClmulSrliEpi64<BITS>(product), ClmulSrliBytes<8>(ClmulSlliEpi64<64 - BITS>(product)));
         if (BITS + POS <= 66) {
-            __m128i red1 = _mm_xor_si128(high1, _mm_slli_epi64(high1, POS));
+            Clmul128 red1 = ClmulXor(high1, ClmulSlliEpi64<POS>(high1));
             if (POS == 1) {
-                return _mm_cvtsi128_si64(_mm_xor_si128(product, red1)) & MASK;
+                return ClmulExtract64(ClmulXor(product, red1)) & MASK;
             } else if (BITS + POS <= 66) {
-                __m128i high2 = _mm_srli_epi64(red1, BITS);
-                __m128i red2 = _mm_xor_si128(high2, _mm_slli_epi64(high2, POS));
-                return _mm_cvtsi128_si64(_mm_xor_si128(_mm_xor_si128(product, red1), red2)) & MASK;
+                Clmul128 high2 = ClmulSrliEpi64<BITS>(red1);
+                Clmul128 red2 = ClmulXor(high2, ClmulSlliEpi64<POS>(high2));
+                return ClmulExtract64(ClmulXor(ClmulXor(product, red1), red2)) & MASK;
             }
         } else {
-            const __m128i MOD128 = _mm_cvtsi64_si128(1 + (((uint64_t)1) << POS));
-            __m128i red1 = _mm_clmulepi64_si128(high1, MOD128, 0x00);
-            __m128i high2 = _mm_or_si128(_mm_srli_epi64(red1, BITS), _mm_srli_si128(_mm_slli_epi64(red1, 64 - BITS), 8));
-            __m128i red2 = _mm_xor_si128(high2, _mm_slli_epi64(high2, POS));
-            return _mm_cvtsi128_si64(_mm_xor_si128(_mm_xor_si128(product, red1), red2)) & MASK;
+            const ClmulPoly MOD128 = ClmulLoad64(1 + (((uint64_t)1) << POS));
+            Clmul128 red1 = Clmul00(ClmulAsPoly(high1), MOD128);
+            Clmul128 high2 = ClmulOr(ClmulSrliEpi64<BITS>(red1), ClmulSrliBytes<8>(ClmulSlliEpi64<64 - BITS>(red1)));
+            Clmul128 red2 = ClmulXor(high2, ClmulSlliEpi64<POS>(high2));
+            return ClmulExtract64(ClmulXor(ClmulXor(product, red1), red2)) & MASK;
         }
     }
 }

--- a/src/minisketch.cpp
+++ b/src/minisketch.cpp
@@ -18,10 +18,23 @@
 #include "sketch.h"
 
 #ifdef HAVE_CLMUL
-#  ifdef _MSC_VER
-#    include <intrin.h>
-#  else
-#    include <cpuid.h>
+#  if defined(__x86_64__) || defined(__i386__) || defined(_M_X64) || defined(_M_IX86)
+#    ifdef _MSC_VER
+#      include <intrin.h>
+#    else
+#      include <cpuid.h>
+#    endif
+#  elif defined(__aarch64__) || defined(__arm__) || defined(_M_ARM64)
+#    if defined(__APPLE__)
+       /* Apple Silicon and A7+ always have PMULL; no runtime check needed. */
+#    elif defined(_WIN32)
+#      include <processthreadsapi.h>
+#    elif defined(__linux__)
+#      include <sys/auxv.h>
+#      include <asm/hwcap.h>
+#    elif defined(__FreeBSD__)
+#      include <sys/auxv.h>
+#    endif
 #  endif
 #endif
 
@@ -66,13 +79,37 @@ enum class FieldImpl {
 #ifdef HAVE_CLMUL
 static inline bool EnableClmul()
 {
-#ifdef _MSC_VER
+#if defined(__x86_64__) || defined(__i386__) || defined(_M_X64) || defined(_M_IX86)
+#  ifdef _MSC_VER
     int regs[4];
     __cpuid(regs, 1);
     return (regs[2] & 0x2);
-#else
+#  else
     uint32_t eax, ebx, ecx, edx;
     return (__get_cpuid(1, &eax, &ebx, &ecx, &edx) && (ecx & 0x2));
+#  endif
+#elif defined(__aarch64__) || defined(__arm__) || defined(_M_ARM64)
+#  if defined(__APPLE__)
+    return true;
+#  elif defined(_WIN32)
+    return IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE) != 0;
+#  elif defined(__linux__)
+#    if defined(__aarch64__)
+    return (getauxval(AT_HWCAP) & HWCAP_PMULL) != 0;
+#    else
+    return (getauxval(AT_HWCAP2) & HWCAP2_PMULL) != 0;
+#    endif
+#  elif defined(__FreeBSD__)
+    unsigned long hwcap = 0;
+    elf_aux_info(AT_HWCAP, &hwcap, sizeof(hwcap));
+    return (hwcap & HWCAP_PMULL) != 0;
+#  else
+    /* Unknown ARM OS: trust the compile-time gate. */
+    return true;
+#  endif
+#else
+    /* Unknown architecture with HAVE_CLMUL defined: trust the compile-time gate. */
+    return true;
 #endif
 }
 #endif


### PR DESCRIPTION
PMULL is the equivalent of the x86 CLMUL instruction for accelerating polynomial multiplication. It's available on many recent ARMv8 chips that support the Cryptography Extension instructions, such as the Broadcom BCM2712 in the Raspberry Pi 5, as well as older chips like the Rockchip RK3399 (used in many Raspberry Pi alternatives).

This PR extends the CLMUL implementation to use PMULL via ARMv8 intrinsics, if support was detected at build time. This provides a 2-4x speedup for sketch decoding, across almost all field element sizes, sketch sizes, and sketch error counts.

<img width="1080" height="759" alt="diff_rk3399" src="https://github.com/user-attachments/assets/b33099d3-96bf-4e89-8b5d-b40c746690bd" />

<img width="1100" height="759" alt="diff_pi5" src="https://github.com/user-attachments/assets/60c9fd3e-4030-46f8-8a68-5676a8e8ea21" />

The raw data used for these plots, the modified bench.cpp code used to generate the data, and Python code to explore that data and generate other plots, are on this branch:

https://github.com/jharveyb/minisketch/commits/pmull_benching/

The TSV-formatted results are in `doc/benchmark_results`.

This PR as-is is passing existing tests, and feature detection at build time works. Left in draft as I'm looking for feedback on the build-time feature detection, and on this approach vs. having a completely separate templated impl in a separate file from the original CLMUL implementation. This option seemed like a smaller diff overall.

Further reference material:

https://developer.arm.com/architectures/instruction-sets/intrinsics/#q=pmull