### PR TITLE
Avoid Clang's `-Wunused-template` under restricted field selections

### DIFF
--- a/src/fields/clmul_common_impl.h
+++ b/src/fields/clmul_common_impl.h
@@ -12,6 +12,7 @@
 
 #include "../int_utils.h"
 #include "../lintrans.h"
+#include "../util.h"
 
 namespace {
 
@@ -28,7 +29,7 @@ namespace {
 #  define NO_SANITIZE_MEMORY
 #endif
 
-template<typename I, int BITS, I MOD> NO_SANITIZE_MEMORY I MulWithClMulReduce(I a, I b)
+template<typename I, int BITS, I MOD> NO_SANITIZE_MEMORY MAYBE_UNUSED I MulWithClMulReduce(I a, I b)
 {
     static constexpr I MASK = Mask<BITS, I>();
 
@@ -65,7 +66,7 @@ template<typename I, int BITS, I MOD> NO_SANITIZE_MEMORY I MulWithClMulReduce(I 
     }
 }
 
-template<typename I, int BITS, int POS> NO_SANITIZE_MEMORY I MulTrinomial(I a, I b)
+template<typename I, int BITS, int POS> NO_SANITIZE_MEMORY MAYBE_UNUSED I MulTrinomial(I a, I b)
 {
     static constexpr I MASK = Mask<BITS, I>();
 

--- a/src/util.h
+++ b/src/util.h
@@ -26,6 +26,20 @@
 #define EXPECT(x,c) (x)
 #endif
 
+#if defined(__has_cpp_attribute)
+#  if __has_cpp_attribute(maybe_unused)
+#    define MAYBE_UNUSED [[maybe_unused]]
+#  endif
+#endif
+
+#ifndef MAYBE_UNUSED
+#  if defined(__GNUC__)
+#    define MAYBE_UNUSED __attribute__((unused))
+#  else
+#    define MAYBE_UNUSED
+#  endif
+#endif
+
 /* Assertion macros */
 
 /**


### PR DESCRIPTION
Clang recently enabled `-Wunused-template` under `-Wall` (see https://github.com/llvm/llvm-project/pull/206123, https://github.com/llvm/llvm-project/pull/207848, https://github.com/llvm/llvm-project/pull/208001), which [breaks](https://my.cdash.org/builds/3714664/build) `-Wall -Werror` builds of downstream projects that compile minisketch with a restricted field set, including Bitcoin Core.

On the master branch @ d1bd01e189e745cd1828707e0a7004b6a6909650:
```console
$ CXXFLAGS="-Wunused-template" cmake -B build -DCMAKE_CXX_COMPILER=clang++ -DMINISKETCH_FIELDS=2
$ cmake --build build
[35/40] Building CXX object src/CMakeFiles/minisketch.dir/fields/clmul_1byte.cpp.o
In file included from /home/hebasto/dev/minisketch/src/fields/clmul_1byte.cpp:12:
/home/hebasto/dev/minisketch/src/fields/clmul_common_impl.h:31:60: warning: unused function template 'MulWithClMulReduce' [-Wunused-template]
   31 | template<typename I, int BITS, I MOD> NO_SANITIZE_MEMORY I MulWithClMulReduce(I a, I b)
      |                                                            ^~~~~~~~~~~~~~~~~~
1 warning generated.
[37/40] Building CXX object src/CMakeFiles/minisketch_verify.dir/fields/clmul_1byte.cpp.o
In file included from /home/hebasto/dev/minisketch/src/fields/clmul_1byte.cpp:12:
/home/hebasto/dev/minisketch/src/fields/clmul_common_impl.h:31:60: warning: unused function template 'MulWithClMulReduce' [-Wunused-template]
   31 | template<typename I, int BITS, I MOD> NO_SANITIZE_MEMORY I MulWithClMulReduce(I a, I b)
      |                                                            ^~~~~~~~~~~~~~~~~~
1 warning generated.
[40/40] Linking CXX executable bin/test-verify
```

Bitcoin Core's case:
```console
$ CXXFLAGS="-Wunused-template" cmake -B build -DCMAKE_CXX_COMPILER=clang++ -DMINISKETCH_FIELDS=32
$ cmake --build build
[16/40] Building CXX object src/CMakeFiles/minisketch.dir/fields/clmul_4bytes.cpp.o
In file included from /home/hebasto/dev/minisketch/src/fields/clmul_4bytes.cpp:12:
/home/hebasto/dev/minisketch/src/fields/clmul_common_impl.h:68:62: warning: unused function template 'MulTrinomial' [-Wunused-template]
   68 | template<typename I, int BITS, int POS> NO_SANITIZE_MEMORY I MulTrinomial(I a, I b)
      |                                                              ^~~~~~~~~~~~
1 warning generated.
[36/40] Building CXX object src/CMakeFiles/minisketch_verify.dir/fields/clmul_4bytes.cpp.o
In file included from /home/hebasto/dev/minisketch/src/fields/clmul_4bytes.cpp:12:
/home/hebasto/dev/minisketch/src/fields/clmul_common_impl.h:68:62: warning: unused function template 'MulTrinomial' [-Wunused-template]
   68 | template<typename I, int BITS, int POS> NO_SANITIZE_MEMORY I MulTrinomial(I a, I b)
      |                                                              ^~~~~~~~~~~~
1 warning generated.
[40/40] Linking CXX executable bin/test-verify
```

---

Alternatively, ~function templates can be moved out of the anonymous namespace~ the anonymous namespace can be switched to a named one (C++ Core Guidelines, [SF.21](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf21-dont-use-an-unnamed-anonymous-namespace-in-a-header)).